### PR TITLE
Fixed a problem with preview on Safari 5.0.2 (and possibly others)

### DIFF
--- a/data/static/js/preview.js
+++ b/data/static/js/preview.js
@@ -1,8 +1,15 @@
 function updatePreviewPane() {
     $("#previewpane").hide();
     var url = location.pathname.replace(/_edit\//,"_preview/");
-    $("#previewpane").load(url, { "raw" : $("#editedText").attr("value") }, function() {convert();} );
-    $("#previewpane").fadeIn(1000);
+    $.post(
+      url,
+      {"raw" : $("#editedText").attr("value")},
+      function(data) {
+        $('#previewpane').html(data);
+        if (typeof(convert) == 'function') { convert(); }
+      },
+      "html");
+    $('#previewpane').fadeIn(1000);
 };
 $(document).ready(function(){
     $("#previewButton").show();


### PR DESCRIPTION
Hi,

I had a problem with the Preview button not working on Safari. I couldn't quite work out why 
jQuery.load wasn't working. I found that replacing it with a call to jQuery.post and explicitly stating that we
were expecting dataType "html" in return worked. 

Also, the updatePreviewPane function was throwing an error anyway because function convert was not always in scope. (I initially thought this was why it wasn't working on Safari.) I added a check to see if the function is defined before calling it. I think the reason that it's not in scope is because I haven't enabled MathML perhaps? 
