### PR TITLE
Have MathML and jsMath show in preview pane

### DIFF
--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -533,6 +533,11 @@ editPage = withData $ \(params :: Params) -> do
                               value "Preview" ]
                    , thediv ! [ identifier "previewpane" ] << noHtml
                    ]
+  let pgScripts' = ["preview.js"]
+  let pgScripts = case mathMethod cfg of
+       JsMathScript -> "jsMath/easy/load.js" : pgScripts'
+       MathML       -> "MathMLinHTML.js" : pgScripts'
+       _            -> pgScripts'
   formattedPage defaultPageLayout{
                   pgPageName = page,
                   pgMessages = messages,
@@ -541,7 +546,7 @@ editPage = withData $ \(params :: Params) -> do
                   pgShowSiteNav = False,
                   pgMarkupHelp = Just $ markupHelp cfg,
                   pgSelectedTab = EditTab,
-                  pgScripts = ["preview.js"],
+                  pgScripts = pgScripts,
                   pgTitle = ("Editing " ++ page)
                   } editForm
 

--- a/data/static/js/preview.js
+++ b/data/static/js/preview.js
@@ -6,10 +6,15 @@ function updatePreviewPane() {
       {"raw" : $("#editedText").attr("value")},
       function(data) {
         $('#previewpane').html(data);
+        // Process any mathematics if we're using MathML
         if (typeof(convert) == 'function') { convert(); }
+        // Process any mathematics if we're using jsMath
+        if (typeof(jsMath) == 'object')    { jsMath.ProcessBeforeShowing(); }
       },
       "html");
+
     $('#previewpane').fadeIn(1000);
+
 };
 $(document).ready(function(){
     $("#previewButton").show();


### PR DESCRIPTION
Hi John,

I just made a small patch so that MathML and jsMath mathematics can be shown in the preview pane. I wasn't entirely happy with the way I wrote the patch. I would very much have liked to have used a ContentTransformer but couldn't quite work out how to get that to work with the editPage handler. If you could explain how you would go about that to me I'd be very grateful.

Sean
