### PR TITLE
bump sha1 limit

### DIFF
--- a/gitit.cabal
+++ b/gitit.cabal
@@ -130,7 +130,7 @@ Executable           gitit
                      bytestring,
                      random,
                      utf8-string >= 0.3 && < 0.4,
-                     SHA > 1 && < 1.5, HTTP >= 4000.0 && < 4000.2,
+                     SHA > 1 && < 1.6, HTTP >= 4000.0 && < 4000.2,
                      HStringTemplate >= 0.6 && < 0.7,
                      network >= 2.1.0.0 && < 2.4,
                      old-locale >= 1,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
