### PR TITLE
Listen interface explanation on help file could be more clear (#266)

### DIFF
--- a/gitit.hs
+++ b/gitit.hs
@@ -110,7 +110,7 @@ flags =
    , Option ['p'] ["port"] (ReqArg (Port . read) "PORT")
         "Specify port"
    , Option ['l'] ["listen"] (ReqArg (Listen . checkListen) "INTERFACE")
-        "Specify interface to listen on"
+        "Specify IP address to listen on"
    , Option [] ["print-default-config"] (NoArg PrintDefaultConfig)
         "Print default configuration"
    , Option [] ["debug"] (NoArg Debug)


### PR DESCRIPTION
Changing text for interface option that appears in "help" to be more clear.  Changing "Specify interface to listen on" to "Specify IP address to listen on".
