### PR TITLE
additional decoding fix

### DIFF
--- a/Network/Gitit/Framework.hs
+++ b/Network/Gitit/Framework.hs
@@ -179,7 +179,7 @@ unlessNoDelete responder fallback = withData $ \(params :: Params) -> do
 
 -- | Returns the current path (subtracting initial commands like @\/_edit@).
 getPath :: ServerMonad m => m String
-getPath = liftM (fromJust . decString True . intercalate "/" . rqPaths) askRq
+getPath = liftM (intercalate "/" . rqPaths) askRq
 
 -- | Returns the current page name (derived from the path).
 getPage :: GititServerPart String


### PR DESCRIPTION
there is a problem that getPage tries to decode URL when it was already decoded by ackRq, so non-ASCI urls fails to work. This patch fixes situation.
