### PR TITLE
fixed dup dropExtension on categoryPage

### DIFF
--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -704,7 +704,7 @@ categoryPage = do
              forM pages $ \f -> do
                categories <- liftIO $ readCategories $ repoPath </> f
                return $ if category `elem` categories
-                           then Just $ dropExtension f
+                           then Just f
                            else Nothing
   base' <- getWikiBase
   let toMatchListItem file = li <<


### PR DESCRIPTION
see http://gitit.net/dot.included.wikiname and http://gitit.net/_category/sandbox .
It fixed.
(sorry, I cannot speak english well.)
