### PR TITLE
MathJax rendering in edit preview fixed

### DIFF
--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -541,6 +541,7 @@ editPage' params = do
   let pgScripts'' = case mathMethod cfg of
        JsMathScript -> "jsMath/easy/load.js" : pgScripts'
        MathML       -> "MathMLinHTML.js" : pgScripts'
+       MathJax url  -> url : pgScripts'
        _            -> pgScripts'
   formattedPage defaultPageLayout{
                   pgPageName = page,

--- a/data/static/js/preview.js
+++ b/data/static/js/preview.js
@@ -10,6 +10,12 @@ function updatePreviewPane() {
         if (typeof(convert) == 'function') { convert(); }
         // Process any mathematics if we're using jsMath
         if (typeof(jsMath) == 'object')    { jsMath.ProcessBeforeShowing(); }
+        // Process any mathematics if we're using MathJax
+        if (typeof(window.MathJax) == 'object') {
+          // http://docs.mathjax.org/en/latest/typeset.html
+          var math = document.getElementById("MathExample");
+          MathJax.Hub.Queue(["Typeset",MathJax.Hub,math]);
+        }
       },
       "html");
 


### PR DESCRIPTION
MathJax formulas didn't render in edit preview mode for two reasons:
1. No mathjax script was included in preview page (fixed in  Network/Gitit/Handlers.hs)
2. No rendering update was done after pressing "Preview" button (fixed in data/static/js/preview.js). Not sure if it's the easiest way to detect if we're using mathjax (I have knowledge neither in JS nor in MathJax), however, that works :)
