### PR TITLE
Upgrade directory package dependency to 1.2

### DIFF
--- a/Network/Gitit/Cache.hs
+++ b/Network/Gitit/Cache.hs
@@ -27,7 +27,7 @@ where
 import qualified Data.ByteString as B (ByteString, readFile, writeFile)
 import System.FilePath
 import System.Directory (doesFileExist, removeFile, createDirectoryIfMissing, getModificationTime)
-import System.Time (ClockTime)
+import Data.Time.Clock (UTCTime)
 import Network.Gitit.State
 import Network.Gitit.Types
 import Control.Monad
@@ -53,7 +53,7 @@ expireCachedPDF file =
     exists <- doesFileExist pdfname
     when exists $ removeFile pdfname
 
-lookupCache :: String -> GititServerPart (Maybe (ClockTime, B.ByteString))
+lookupCache :: String -> GititServerPart (Maybe (UTCTime, B.ByteString))
 lookupCache file = do
   cfg <- getConfig
   let target = encodeString $ cacheDir cfg </> file

--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -64,7 +64,6 @@ import Network.Gitit.ContentTransformer (showRawPage, showFileAsText, showPage,
         exportPage, showHighlightedSource, preview, applyPreCommitPlugins)
 import Network.Gitit.Page (readCategories)
 import Control.Exception (throwIO, catch, try)
-import System.Time
 import System.FilePath
 import Prelude hiding (catch)
 import Network.Gitit.State
@@ -78,7 +77,7 @@ import Control.Monad.Reader
 import qualified Data.ByteString.Lazy as B
 import qualified Data.ByteString as S
 import Network.HTTP (urlEncodeVars)
-import Data.Time (getCurrentTime, addUTCTime)
+import Data.Time.Clock
 import Data.FileStore
 import System.Log.Logger (logM, Priority(..))
 
@@ -117,9 +116,9 @@ randomPage = do
   if null pages
      then error "No pages found!"
      else do
-       TOD _ picosecs <- liftIO getClockTime
+       secs <- liftIO (fmap utctDayTime getCurrentTime)
        let newPage = pages !!
-                     ((fromIntegral picosecs `div` 1000000) `mod` length pages)
+                     (truncate (secs * 1000000) `mod` length pages)
        seeOther (base' ++ urlForPage newPage) $ toResponse $
          p << "Redirecting to a random page"
 
@@ -769,9 +768,8 @@ feedHandler = do
   let file = (path' `orIfNull` "_site") <.> "feed"
   let mbPath = if null path' then Nothing else Just path'
   -- first, check for a cached version that is recent enough
-  now <- liftIO $ getClockTime
-  let isRecentEnough t = normalizeTimeDiff (diffClockTimes now t) <
-                         normalizeTimeDiff (noTimeDiff{tdMin = fromIntegral $ feedRefreshTime cfg})
+  now <- liftIO $ getCurrentTime
+  let isRecentEnough t = truncate (diffUTCTime now t) < 60 * feedRefreshTime cfg
   mbCached <- lookupCache file
   case mbCached of
        Just (modtime, contents) | isRecentEnough modtime -> do

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -138,7 +138,7 @@ Executable           gitit
                      pandoc-types >= 1.9.0.2 && < 1.10,
                      process,
                      filepath,
-                     directory,
+                     directory >= 1.2,
                      mtl,
                      cgi,
                      old-time,


### PR DESCRIPTION
Fix compilation issue with GHC 7.6.1. In newer version of directory,
`getModificationTime` used `UTCTime` from time package as result
type. This change breaks the build of gitit.
