### PR TITLE
duplicate unescaping to html-entity

### DIFF
--- a/Network/Gitit/Types.hs
+++ b/Network/Gitit/Types.hs
@@ -300,7 +300,7 @@ instance FromReqURI [String] where
 
 instance FromData Params where
      fromData = do
-         let look' = liftM fromEntities . look
+         let look' = look
          un <- look' "username"       `mplus` return ""
          pw <- look' "password"       `mplus` return ""
          p2 <- look' "password2"      `mplus` return ""


### PR DESCRIPTION
http://gitit.net/sandbox/entity-test
html-entity (＆ａｍｐ；ａｍｐ；...) reduced by each editing to page.
It is duplicate unescaping to html-entity.

I guess already unescaped by pandoc (or other libs).
