### PR TITLE
supply $revision$ at _diff if "Changes from beginning to ..." 

### DIFF
--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -460,7 +460,7 @@ showDiff file page params = do
        Left e         -> liftIO $ throwIO e
        Right htmlDiff -> formattedPage defaultPageLayout{
                                           pgPageName = page,
-                                          pgRevision = from',
+                                          pgRevision = from' `mplus` to,
                                           pgMessages = pMessages params,
                                           pgTabs = DiffTab :
                                                    pgTabs defaultPageLayout,


### PR DESCRIPTION
I create new page.
and, I see http://gitit.net/_activity .
this changes were linked to _diff pages.
( http://gitit.net/_diff/sandobox/new-page?to=9fae7f556dd609efdd546787dd7273dc7b17cd4a and http://gitit.net/_diff/sandobox/new-page?to=23c4064f7bd8a82b8d4c1d9e2e6631d2ed01e0ca )
this is ok. I go to "view" link in tabs.
one was ok(this revision's "view"), but other was not ok(link to recent version of this page).
this problem was occured by not supplied to $revision$ when new page created.
this patch it supply. but it is inaccurate a bit.
