### PR TITLE
Specify correct format header for initial pages

### DIFF
--- a/Network/Gitit/Initialize.hs
+++ b/Network/Gitit/Initialize.hs
@@ -126,7 +126,7 @@ createDefaultPages conf = do
                         , writerLiterateHaskell = showLHSBirdTracks conf
                         }
         -- note: we convert this (markdown) to the default page format
-        converter = case defaultPageType conf of
+        converter = case pt of
                        Markdown -> id
                        LaTeX    -> writeLaTeX defOpts . toPandoc
                        HTML     -> writeHtmlString defOpts . toPandoc
@@ -143,7 +143,9 @@ createDefaultPages conf = do
     usersguidepath <- getDataFileName "README.markdown"
     usersguidecontents <- liftM converter $ readFileUTF8 usersguidepath
     -- include header in case user changes default format:
-    let header = "---\nformat: markdown\n...\n\n"
+    let header = "---\nformat: " ++
+          show pt ++ (if defaultLHS conf then "+lhs" else "") ++
+          "\n...\n\n"
     -- add front page, help page, and user's guide
     let auth = Author "Gitit" ""
     createIfMissing fs (frontPage conf <.> "page") auth "Default front page"


### PR DESCRIPTION
#329 was fixed by specifying `format: markdown` headers for the default pages. However, when the default page syntax is not markdown, the default pages get converted into whatever it is – but still specify `format: markdown`.

The attached commit specifies whatever the default page syntax is.
