### PR TITLE
Custom MathJax rendering script option

### DIFF
--- a/Network/Gitit/Config.hs
+++ b/Network/Gitit/Config.hs
@@ -66,6 +66,7 @@ extractConfig cp = do
       cfRepositoryPath <- get cp "DEFAULT" "repository-path"
       cfDefaultPageType <- get cp "DEFAULT" "default-page-type"
       cfMathMethod <- get cp "DEFAULT" "math"
+      cfMathjaxScript <- get cp "DEFAULT" "mathjax-script"
       cfShowLHSBirdTracks <- get cp "DEFAULT" "show-lhs-bird-tracks"
       cfRequireAuthentication <- get cp "DEFAULT" "require-authentication"
       cfAuthenticationMethod <- get cp "DEFAULT" "authentication-method"
@@ -132,7 +133,7 @@ extractConfig cp = do
         , mathMethod           = case map toLower cfMathMethod of
                                       "jsmath"   -> JsMathScript
                                       "mathml"   -> MathML
-                                      "mathjax"  -> MathJax "https://d3eoax9i5htok0.cloudfront.net/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+                                      "mathjax"  -> MathJax cfMathjaxScript
                                       "google"   -> WebTeX "http://chart.apis.google.com/chart?cht=tx&chl="
                                       _          -> RawTeX
         , defaultLHS           = lhs

--- a/data/default.conf
+++ b/data/default.conf
@@ -76,6 +76,16 @@ math: MathML
 # API is called to render the formula as an image. This requires a connection
 # to google, and might raise a technical or a privacy problem.
 
+mathjax-script: https://d3eoax9i5htok0.cloudfront.net/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+# specifies the path to MathJax rendering script.
+# You might want to use your own MathJax script to render formulas without
+# Internet connection or if you want to use some special LaTeX packages.
+# Note: path specified there cannot be an absolute path to a script on your hdd, 
+# instead you should run your (local if you wish) HTTP server which will 
+# serve the MathJax.js script. You can easily (in four lines of code) serve
+# MathJax.js using http://happstack.com/docs/crashcourse/FileServing.html
+# Do not forget the "http://" prefix (e.g. http://localhost:1234/MathJax.js)
+
 show-lhs-bird-tracks: no
 # specifies whether to show Haskell code blocks in "bird style",
 # with "> " at the beginning of each line.


### PR DESCRIPTION
For some reason path to `MathJax.js` has been hardcoded, so I made the `mathjax-script` option in config to make it possible to specify the path to the script.

I am not sure if there is confusion in my description of `mathjax-script` option in the `default.conf` file: you have to either run your own web server (not that hard, but anyway) or copy the entire MathJax directory into gitit's `data/static/js` directory (which is not the way it is intended to be done, I guess), so there is no per-wiki directory for custom js files?

P.S. Why is some random blahblahblah.cloudfront.net being used, not cdn.mathjax.org?
