### PR TITLE
Highlighting in slides exportgs

### DIFF
--- a/Network/Gitit/Export.hs
+++ b/Network/Gitit/Export.hs
@@ -136,7 +136,7 @@ respondSlides templ slideVariant page doc = do
                ,writerTemplate = template
                ,writerSourceDirectory = repositoryPath cfg
                ,writerUserDataDir = pandocUserData cfg
-               } (Pandoc meta [])
+               } (Pandoc meta blocks)
     h' <- liftIO $ makeSelfContained (pandocUserData cfg) h
     ok . setContentType "text/html;charset=UTF-8" .
       -- (setFilename (page ++ ".html")) .


### PR DESCRIPTION
Highlighting code in slides exports is broken since 0.9. See example at http://gitit.net/slides%20highlighting.

This patch fixes the issue, although I'm not very familiar with Pandoc's API, and I'm afraid it might break something else.
