### PR TITLE
Fix wiki links when `base-url` is set to empty and `absolute-urls` to yes

### DIFF
--- a/Network/Gitit/ContentTransformer.hs
+++ b/Network/Gitit/ContentTransformer.hs
@@ -525,7 +525,7 @@ wikiLinksTransform pandoc
 -- | Convert links with no URL to wikilinks.
 convertWikiLinks :: Config -> Inline -> Inline
 convertWikiLinks cfg (Link ref ("", "")) | useAbsoluteUrls cfg =
-  Link ref (baseUrl cfg </> inlinesToURL ref, "Go to wiki page")
+  Link ref ("/" </> baseUrl cfg </> inlinesToURL ref, "Go to wiki page")
 convertWikiLinks _cfg (Link ref ("", "")) =
   Link ref (inlinesToURL ref, "Go to wiki page")
 convertWikiLinks _cfg x = x


### PR DESCRIPTION
In config file, when `base-url` is set to empty (or `/`, which will then be trailed to empty) and `absolute-urls` set to yes, the wiki links doesn't actually use absolute urls, since it will use `</>` to concat `base-url` and the wiki link.

So in page `/Sub/Page`, the link `[OtherPage]` will produce the code `<a href="OtherPage">` thus point to `/Sub/OtherPage`, while it should produce the code `<a href="/OtherPage">`.

We should always concat a `'/'` before the `base-url` to make sure the produced url is an absolute url.
