### PR TITLE
Support + in page and category names

### DIFF
--- a/Network/Gitit/Framework.hs
+++ b/Network/Gitit/Framework.hs
@@ -211,7 +211,7 @@ getReferer = do
 getWikiBase :: ServerMonad m => m String
 getWikiBase = do
   path' <- getPath
-  uri' <- liftM (fromJust . decString True . rqUri) askRq
+  uri' <- liftM (fromJust . decString False . rqUri) askRq
   case calculateWikiBase path' uri' of
        Just b    -> return b
        Nothing   -> error $ "Could not getWikiBase: (path, uri) = " ++ show (path',uri')


### PR DESCRIPTION
Spaces were incorrectly decoded to spaces in URIs. Wiki pages and categories with '+' in their names were accessible only through a link with encoded + (%2B), but this should not be necessary.

This patch worked for me in some simple tests (creating, viewing and editing pages with spaces and/or + in them, such as "C++", "C++ libraries" or "Foo Bar").
