### PR TITLE
Activity page with binary files

### DIFF
--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -399,7 +399,7 @@ showActivity = withData $ \(params :: Params) -> do
   let fileAnchor revis file = if isPageFile file
         then anchor ! [href $ base' ++ "/_diff" ++ urlForPage(dropExtension(file)) ++ "?to=" ++ revis] << dropExtension file
         else anchor ! [href $ base' ++ urlForPage file ] << file
-  let filesFor changes revis = intersperse (primHtmlChar "nbsp") $
+  let filesFor changes revis = intersperse (stringToHtml " ") $
         map (fileAnchor revis . fileFromChange) changes
   let heading = h1 << ("Recent changes by " ++ fromMaybe "all users" forUser)
   let revToListItem rev = li <<


### PR DESCRIPTION
Hi, 

It looks that the current activity page is broken when images/binary files are uploaded In that case the links lead to nowhere. In the patch I fix that by just pointing to the new version of the binary files.

I also space the links to changed files with normal spaces instead of nbsp, as it makes very long lines if multiple files were changed

Feel free to merge or ignore.

Cheers.
       Sergey
