### PR TITLE
Change _search to use HTTP GET

### DIFF
--- a/Network/Gitit.hs
+++ b/Network/Gitit.hs
@@ -171,7 +171,7 @@ wikiHandlers =
     guardBareBase >> getWikiBase >>= \b -> movedPermanently (b ++ "/") (toResponse ())
   , dir "_activity" showActivity
   , dir "_go"       goToPage
-  , dir "_search"   searchResults
+  , method GET >> dir "_search"   searchResults
   , dir "_upload"   $  do guard =<< return . uploadsAllowed =<< getConfig
                           msum [ method GET  >> authenticate ForModify uploadForm
                                  , method POST >> authenticate ForModify uploadFile ]

--- a/data/templates/sitenav.st
+++ b/data/templates/sitenav.st
@@ -15,7 +15,7 @@
       $endif$
       <li><a href="$base$/Help">Help</a></li>
     </ul>
-    <form action="$base$/_search" method="post" id="searchform">
+    <form action="$base$/_search" method="get" id="searchform">
      <input type="text" name="patterns" id="patterns"/>
      <input type="submit" name="search" id="search" value="Search"/>
     </form>


### PR DESCRIPTION
We had a user complain that they weren't able to refresh search results. Changing _search to a GET request makes searches refreshable and shareable. Also this is a standard practice for searches.

This is the second usability issue we found. The first is #397
