### PR TITLE
Create page if no match is found when using _go

### DIFF
--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -242,7 +242,6 @@ goToPage = withData $ \(params :: Params) -> do
   let findPage f = find f allPageNames
   let exactMatch f = gotopage == f
   let insensitiveMatch f = (map toLower gotopage) == (map toLower f)
-  let prefixMatch f = (map toLower gotopage) `isPrefixOf` (map toLower f)
   base' <- getWikiBase
   case findPage exactMatch of
        Just m  -> seeOther (base' ++ urlForPage m) $ toResponse
@@ -250,11 +249,8 @@ goToPage = withData $ \(params :: Params) -> do
        Nothing -> case findPage insensitiveMatch of
                        Just m  -> seeOther (base' ++ urlForPage m) $ toResponse
                                     "Redirecting to case-insensitive match"
-                       Nothing -> case findPage prefixMatch of
-                                       Just m  -> seeOther (base' ++ urlForPage m) $
-                                                  toResponse $ "Redirecting" ++
-                                                    " to partial match"
-                                       Nothing -> searchResults
+                       Nothing -> seeOther (base' ++ urlForPage gotopage) $ toResponse
+                                    "Redirecting to new page"
 
 searchResults :: Handler
 searchResults = withData $ \(params :: Params) -> do


### PR DESCRIPTION
We recently deployed gitit as our corporate wiki at my company, and we love it, but we have a couple complaints about some usability issues from non-technical users. 

The first was that they couldn't figure out how to create new pages. They assumed it worked like wikimedia and you use the 'go' box. But this would go to a existing page if there was a prefix match which was unexpected and undesired behavior because they wanted to create a page that was a prefix of an existing page. This pull request fixes that issue.

The second issue is #396
