### PR TITLE
Document added mod_proxy_html setting in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -545,6 +545,7 @@ Now add the following lines to the apache configuration file for the
       SetOutputFilter  proxy-html
       ProxyPassReverse /
       ProxyHTMLURLMap  /   /wiki/
+      ProxyHTMLDocType "<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Strict//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>" XHTML
       RequestHeader unset Accept-Encoding
     </Location>
 


### PR DESCRIPTION
This is a minor/trivial documentation update, which adds a ProxyHTMLDocType directive for Apache's mod_proxy_html, in the case where the user is using Apache to proxy to e.g. "http://mysite.com/wiki".

This directive instructs mod_proxy_html to re-add the DOCTYPE string which it would otherwise strip.  Without the DOCTYPE string, there are a number of subtle differences in rendered pages.  Most notably, highlighted source code with page numbers are misaligned.  (Tested under both Safari and Chrome.)

The new form of the ProxyHTMLDocType directive (which includes the entire DOCTYPE string) needs to be used, otherwise mod_proxy_html "sanitises" the HTML, which results in MathML-rendered formulae being broken.
