### PR TITLE
Added new template variables isdiscusspage, articleUrl and discussionUrl.

### DIFF
--- a/Network/Gitit/Layout.hs
+++ b/Network/Gitit/Layout.hs
@@ -79,7 +79,7 @@ filledPageTemplate base' cfg layout htmlContents templ =
                            'h':'t':'t':'p':_  -> x
                            _                  -> base' ++ "/js/" ++ x
 
-      scripts  = ["jquery.min.js", "jquery-ui.packed.js", "footnotes.js"] ++ pgScripts layout
+      scripts  = ["jquery.min.js", "jquery-ui.packed.js", "footnotesispage.js"] ++ pgScripts layout
       scriptLink x = script ! [src (prefixedScript x),
         thetype "text/javascript"] << noHtml
       javascriptlinks = renderHtmlFragment $ concatHtml $ map scriptLink scripts
@@ -99,10 +99,14 @@ filledPageTemplate base' cfg layout htmlContents templ =
                    setStrAttr "pagetitle" (pgTitle layout) .
                    T.setAttribute "javascripts" javascriptlinks .
                    setStrAttr "pagename" page .
+                   setStrAttr "articlename" article .
+                   setStrAttr "discussionname" discussion .
                    setStrAttr "pageUrl" (urlForPage page) .
                    setStrAttr "articleUrl" (urlForPage article) .
                    setStrAttr "discussionUrl" (urlForPage discussion) .
                    setBoolAttr "ispage" (isPage page) .
+                   setBoolAttr "isarticlepage" (isPage page && not (isDiscussPage page)) .
+                   setBoolAttr "isdiscusspage" (isDiscussPage page) .
                    setBoolAttr "pagetools" (pgShowPageTools layout) .
                    setBoolAttr "sitenav" (pgShowSiteNav layout) .
                    maybe id (T.setAttribute "markuphelp") (pgMarkupHelp layout) .


### PR DESCRIPTION
This makes it possible to treat discussion pages specially in the templates, and to have links between the article page and the discussion page.

I need this for a theme I'm working on, which doesn't use the "tabs". I believe as well that with this change, you could implement the "tabs" more or less entirely in the templates, without needing to hard-code them into the server-side logic. However, I didn't want to make such an invasive change myself, I want to leave that up to other people.

This has other uses as well, I'm not the first person to look for this feaure. See [here](https://groups.google.com/forum/#!msg/gitit-discuss/cRe3fl0IaLE/5Fese-7elVcJ) for example.
