### PR TITLE
Added hasmessages template variable

### DIFF
--- a/Network/Gitit/Layout.hs
+++ b/Network/Gitit/Layout.hs
@@ -107,8 +107,7 @@ filledPageTemplate base' cfg layout htmlContents templ =
                    T.setAttribute "exportbox"
                        (renderHtmlFragment $  exportBox base' cfg page rev) .
                    T.setAttribute "tabs" (renderHtmlFragment tabs) .
-                   setBoolAttr "hasmessages" (not . null $ pgMessages layout) .
-                   T.setAttribute "messages" (pgMessages layout) .
+                   (\f x xs -> if null xs then x else f xs) (T.setAttribute "messages") id (pgMessages layout) .
                    T.setAttribute "usecache" (useCache cfg) .
                    T.setAttribute "content" (renderHtmlFragment htmlContents) .
                    setBoolAttr "wikiupload" ( uploadsAllowed cfg) $

--- a/data/templates/content.st
+++ b/data/templates/content.st
@@ -3,7 +3,7 @@
     <h2 class="revision">Revision $revision$</h2>
   $endif$
   <h1 class="pageTitle"><a href="$base$$pageUrl$">$pagetitle$</a></h1>
-  $if(hasmessages)$
+  $if(messages)$
     $messages()$
   $endif$
   $content$


### PR DESCRIPTION
In the content.st template, there is a conditional $if(messages)$ around the inclusion of the messages.st subtemplate. However, this always evaluates to true, even if the messages list is empty.

I can't find any good documentation for HStringTemplate's conditionals, so I don't know if this is the correct behaviour or not; in any case, I added the hasmessages template variable, which will be set to False when messages is empty. I also modified the content.st template accordingly. Now the messages.st subtemplate is only included when messages is non-empty.
