### PR TITLE
Add "search for pages containing..." option to `createPage`

### DIFF
--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -141,12 +141,13 @@ createPage = do
                                     , pgTabs = []
                                     , pgTitle = "Create " ++ page ++ "?"
                                     } $
-                    (p << stringToHtml ("There is no page named '" ++ page ++
-                        "'. You can:")) +++
+                    (p << stringToHtml
+                        ("There is no page named '" ++ page ++ "'. You can:"))
+                        +++
                     (unordList $
                       [ anchor !
                             [href $ base' ++ "/_edit" ++ urlForPage page] <<
-                              ("Create the page “" ++ page ++ "”")
+                              ("Create the page '" ++ page ++ "'")
                       , anchor !
                             [href $ base' ++ "/_search?" ++
                                 (urlEncodeVars [("patterns", page)])] <<


### PR DESCRIPTION
Changed the "page not found" page to give the option of searching for the page name in other pages in addition to the option to create the page with that name.
