### PR TITLE
Removed access question from password reset form, only for register form

### DIFF
--- a/Network/Gitit/Authentication.hs
+++ b/Network/Gitit/Authentication.hs
@@ -215,7 +215,9 @@ sharedForm mbUser = withData $ \params -> do
   dest <- case pDestination params of
                 ""  -> getReferer
                 x   -> return x
-  let accessQ = case accessQuestion cfg of
+  let accessQ = case mbUser of
+            Just _ -> noHtml
+            Nothing -> case accessQuestion cfg of
                       Nothing          -> noHtml
                       Just (prompt, _) -> label << prompt +++ br +++
                                           X.password "accessCode" ! [size "15", intAttr "tabindex" 1]
@@ -279,9 +281,11 @@ sharedValidation validationType params = do
   let optionalTests Register =
           [(taken, "Sorry, that username is already taken.")]
       optionalTests ResetPassword = []
-  let isValidAccessCode = case accessQuestion cfg of
-        Nothing           -> True
-        Just (_, answers) -> accessCode `elem` answers
+  let isValidAccessCode = case validationType of
+        ResetPassword -> True
+        Register -> case accessQuestion cfg of
+            Nothing           -> True
+            Just (_, answers) -> accessCode `elem` answers
   let isValidEmail e = length (filter (=='@') e) == 1
   peer <- liftM (fst . rqPeer) askRq
   captchaResult <-


### PR DESCRIPTION
This is the behaviour that I want for my gitit instance, I don't know if it's what other people want, but I think it makes more sense. I'm throwing it out there to see what people think.
