### PR TITLE
Improvements to search.js

### DIFF
--- a/data/static/js/search.js
+++ b/data/static/js/search.js
@@ -2,7 +2,8 @@ jQuery.fn.highlightPattern = function (patt, className)
 {
     // patt is a space separated list of strings - we want to highlight
     // an occurrence of any of these strings as a separate word.
-    var regex = new RegExp('\\b(' + patt.replace(/ /g, '|') + ')\\b', 'gi');
+    var epatt = patt.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1")
+    var regex = new RegExp('(' + epatt.replace(/ /g, '|') + ')', 'gi');
 
     return this.each(function ()
     {


### PR DESCRIPTION
These commits make several changes to the bundled `search.js` script that highlights matches in search results.
- In the RegExp, it replaces all spaces in `patt` with the bar (`|`) character; previously only the first was replaced.
- It makes the matching regex case insensitive, since the search handler is also case insensitive.
- It allows search patterns to contain punctuation and regular expression metacharacters, which allows the highlighting of useful queries such as searches for a Markdown link.

One change may have a noticeable impact on past behavior: I had to remove the word boundaries from the regex in order to make the search queries containing punctuation work. This will mean that pattern matches contained within words will be highlighted by the javascript, which may leave the (inaccurate) impression that the Gitit search handler also matches substrings within words.
