### PR TITLE
Handle search patterns that begin or end with punctuation

### DIFF
--- a/data/static/js/search.js
+++ b/data/static/js/search.js
@@ -2,10 +2,10 @@ jQuery.fn.highlightPattern = function (patt, className)
 {
     // check if patt starts or ends with non-word character
     // and set regex boundary accordingly.
-    var start = '(\\b)(';
+    var start = '\\b(';
     var end = ')\\b';
     if (/\W/.test(patt.charAt(0))) {
-       var start = '(\\W)(';
+       var start = '\(?=\\W\)(';
     };
     if (/\W/.test(patt.charAt(patt.length - 1))) {
        var end = ')\(?!\\w\)';
@@ -16,12 +16,12 @@ jQuery.fn.highlightPattern = function (patt, className)
 
     // patt is a space separated list of strings - we want to highlight
     // an occurrence of any of these strings as a separate word.
-    var regex = new RegExp(start + epatt.replace(/ /g, '|') + end, 'gi');
+    var regex = new RegExp(start + epatt.replace(/ /g, '| ') + end, 'gi');
 
     return this.each(function ()
     {
         this.innerHTML = this.innerHTML.replace(regex,
-          '$1<span class=\'' + className + '\'>' + '$2' + '</span>');
+          '<span class=\'' + className + '\'>' + '$1' + '</span>');
     });
 };
 function toggleMatches(obj) {


### PR DESCRIPTION
These changes to `search.js` do two things:

First, they escape regex metacharacters in `patt`. Previously, if the search pattern was something like `[Front Page]()`, then the script would treat `[Front Page]` as a regex character class and highlight all matches of `F`, `r`, `o`, etc.

Fixing that problem introduces another one, which is that searches beginning with punctuation would not match because of the hard-coded word boundary in the RegExp. Since `\b` matches between word characters and non-word-characters, but patterns like `[Front Page]()` typically appear after a non-word character in a file (like space), the regex would fail. 

The ugly, but functional, work around is to change the regex start and end patterns if `patt` begins or ends with a non-word character, and then to preserve the non-word character that precedes the patt when replacing the regex with the highlight span.

P.S. Apologize for the extra commit messages, created by another commit that I reverted. Couldn't figure out how to do rebase, but if you need me to revise, and can advise me on how to make a cleaner pull request, I will.
