### PR TITLE
corrected mathjax CDN URL

### DIFF
--- a/data/default.conf
+++ b/data/default.conf
@@ -76,7 +76,7 @@ math: MathML
 # API is called to render the formula as an image. This requires a connection
 # to google, and might raise a technical or a privacy problem.
 
-mathjax-script: https://d3eoax9i5htok0.cloudfront.net/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+mathjax-script: https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 # specifies the path to MathJax rendering script.
 # You might want to use your own MathJax script to render formulas without
 # Internet connection or if you want to use some special LaTeX packages.


### PR DESCRIPTION
See http://www.mathjax.org/changes-to-the-mathjax-cdn/ for details.
