### PR TITLE
enable highlighting of patterns that start or end with punctuation

### DIFF
--- a/data/static/js/search.js
+++ b/data/static/js/search.js
@@ -1,8 +1,21 @@
 jQuery.fn.highlightPattern = function (patt, className)
 {
+    // check if patt starts or ends with non-word character
+    // and set regex boundary accordingly.
+    var start = '\\b(';
+    var end = ')\\b';
+    if (/\W/.test(patt.charAt(0))) {
+       var start = '\(?=\\W\)(';
+    };
+    if (/\W/.test(patt.charAt(patt.length - 1))) {
+       var end = ')\(?!\\w\)';
+    }
+    // escape regex metacharacters that may be in the patt
+    var epatt = patt.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1")
+
     // patt is a space separated list of strings - we want to highlight
     // an occurrence of any of these strings as a separate word.
-    var regex = new RegExp('\\b(' + patt.replace(/ /g, '|') + ')\\b', 'gi');
+    var regex = new RegExp(start + epatt.replace(/ /g, '| ') + end, 'gi');
 
     return this.each(function ()
     {


### PR DESCRIPTION
Improvements to `search.js` that account for search patterns bounded by punctuation. 
- check to see if patt starts or ends with punctuation
- if it does, use lookarounds instead of \b for regex boundaries
- when replacing spaces in patterns with bar, preserve space after bar
  (this accounts for patterns bounded by punctuation, which switches
  on lookaround behavior, that also contain spaces)
