### PR TITLE
BUG: include takeBaseName in System.FilePath import

### DIFF
--- a/Network/Gitit/Plugins.hs
+++ b/Network/Gitit/Plugins.hs
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 module Network.Gitit.Plugins ( loadPlugin, loadPlugins )
 where
 import Network.Gitit.Types
-import System.FilePath()
+import System.FilePath (takeBaseName)
 import Control.Monad (unless)
 import System.Log.Logger (logM, Priority(..))
 #ifdef _PLUGINS


### PR DESCRIPTION
Build fails otherwise because takeBaseName is out of scope
