### PR TITLE
Make default extension for page file configurable

### DIFF
--- a/Network/Gitit/Cache.hs
+++ b/Network/Gitit/Cache.hs
@@ -50,11 +50,11 @@ expireCachedFile file = do
   exists <- liftIO $ doesFileExist target
   when exists $ liftIO $ do
     liftIO $ removeFile target
-    expireCachedPDF target
+    expireCachedPDF target (defaultExtension cfg)
 
-expireCachedPDF :: String -> IO ()
-expireCachedPDF file =
-  when (takeExtension file == ".page") $ do
+expireCachedPDF :: String -> String -> IO ()
+expireCachedPDF file ext = 
+  when (takeExtension file == "." ++ ext) $ do
     let pdfname = file ++ ".export.pdf"
     exists <- doesFileExist pdfname
     when exists $ removeFile pdfname
@@ -84,4 +84,4 @@ cacheContents file contents = do
   liftIO $ do
     createDirectoryIfMissing True targetDir
     B.writeFile target contents
-    expireCachedPDF target
+    expireCachedPDF target (defaultExtension cfg)

--- a/Network/Gitit/Config.hs
+++ b/Network/Gitit/Config.hs
@@ -83,6 +83,7 @@ extractConfig cp = do
       cfRepositoryType <- get cp "DEFAULT" "repository-type"
       cfRepositoryPath <- get cp "DEFAULT" "repository-path"
       cfDefaultPageType <- get cp "DEFAULT" "default-page-type"
+      cfDefaultExtension <- get cp "DEFAULT" "default-page-type"
       cfMathMethod <- get cp "DEFAULT" "math"
       cfMathjaxScript <- get cp "DEFAULT" "mathjax-script"
       cfShowLHSBirdTracks <- get cp "DEFAULT" "show-lhs-bird-tracks"
@@ -150,6 +151,7 @@ extractConfig cp = do
           repositoryPath       = cfRepositoryPath
         , repositoryType       = repotype'
         , defaultPageType      = pt
+        , defaultExtension     = cfDefaultExtension
         , mathMethod           = case map toLower cfMathMethod of
                                       "jsmath"   -> JsMathScript
                                       "mathml"   -> MathML

--- a/Network/Gitit/Config.hs
+++ b/Network/Gitit/Config.hs
@@ -83,7 +83,7 @@ extractConfig cp = do
       cfRepositoryType <- get cp "DEFAULT" "repository-type"
       cfRepositoryPath <- get cp "DEFAULT" "repository-path"
       cfDefaultPageType <- get cp "DEFAULT" "default-page-type"
-      cfDefaultExtension <- get cp "DEFAULT" "default-page-type"
+      cfDefaultExtension <- get cp "DEFAULT" "default-extension"
       cfMathMethod <- get cp "DEFAULT" "math"
       cfMathjaxScript <- get cp "DEFAULT" "mathjax-script"
       cfShowLHSBirdTracks <- get cp "DEFAULT" "show-lhs-bird-tracks"

--- a/Network/Gitit/ContentTransformer.hs
+++ b/Network/Gitit/ContentTransformer.hs
@@ -111,14 +111,33 @@ import Text.URI (parseURI, URI(..), uriQueryItems)
 -- ContentTransformer runners
 --
 
-runTransformer :: ToMessage a
-               => (String -> String)
-               -> ContentTransformer a
+runPageTransformer :: ToMessage a
+               => ContentTransformer a
                -> GititServerPart a
-runTransformer pathFor xform = withData $ \params -> do
+runPageTransformer xform = withData $ \params -> do
   page <- getPage
   cfg <- getConfig
-  evalStateT xform  Context{ ctxFile = pathFor page
+  evalStateT xform  Context{ ctxFile = pathForPage page (defaultExtension cfg)
+                           , ctxLayout = defaultPageLayout{
+                                             pgPageName = page
+                                           , pgTitle = page
+                                           , pgPrintable = pPrintable params
+                                           , pgMessages = pMessages params
+                                           , pgRevision = pRevision params
+                                           , pgLinkToFeed = useFeed cfg }
+                           , ctxCacheable = True
+                           , ctxTOC = tableOfContents cfg
+                           , ctxBirdTracks = showLHSBirdTracks cfg
+                           , ctxCategories = []
+                           , ctxMeta = [] }
+
+runFileTransformer :: ToMessage a
+               => ContentTransformer a
+               -> GititServerPart a
+runFileTransformer xform = withData $ \params -> do
+  page <- getPage
+  cfg <- getConfig
+  evalStateT xform  Context{ ctxFile = id page
                            , ctxLayout = defaultPageLayout{
                                              pgPageName = page
                                            , pgTitle = page
@@ -134,17 +153,17 @@ runTransformer pathFor xform = withData $ \params -> do
 
 -- | Converts a @ContentTransformer@ into a @GititServerPart@;
 -- specialized to wiki pages.
-runPageTransformer :: ToMessage a
-                   => ContentTransformer a
-                   -> GititServerPart a
-runPageTransformer = runTransformer pathForPage
+-- runPageTransformer :: ToMessage a
+--                    => ContentTransformer a
+--                    -> GititServerPart a
+-- runPageTransformer = runTransformer pathForPage
 
 -- | Converts a @ContentTransformer@ into a @GititServerPart@;
 -- specialized to non-pages.
-runFileTransformer :: ToMessage a
-                   => ContentTransformer a
-                   -> GititServerPart a
-runFileTransformer = runTransformer id
+-- runFileTransformer :: ToMessage a
+--                    => ContentTransformer a
+--                    -> GititServerPart a
+-- runFileTransformer = runTransformer id
 
 --
 -- Gitit responders

--- a/Network/Gitit/Export.hs
+++ b/Network/Gitit/Export.hs
@@ -214,7 +214,7 @@ respondPDF :: Bool -> String -> Pandoc -> Handler
 respondPDF useBeamer page old_pndc = fixURLs page old_pndc >>= \pndc -> do
   cfg <- getConfig
   unless (pdfExport cfg) $ error "PDF export disabled"
-  let cacheName = pathForPage page ++ ".export.pdf"
+  let cacheName = pathForPage page (defaultExtension cfg) ++ ".export.pdf"
   cached <- if useCache cfg
                then lookupCache cacheName
                else return Nothing

--- a/Network/Gitit/Framework.hs
+++ b/Network/Gitit/Framework.hs
@@ -43,6 +43,7 @@ module Network.Gitit.Framework (
                                , isPageFile
                                , isDiscussPage
                                , isDiscussPageFile
+                               , isNotDiscussPageFile
                                , isSourceCode
                                -- * Combinators that change the request locally
                                , withMessages
@@ -255,16 +256,22 @@ isPage s = all (`notElem` "*?") s && not (".." `isInfixOf` s) && not ("/_" `isIn
 -- for now, we disallow @*@ and @?@ in page names, because git filestore
 -- does not deal with them properly, and darcs filestore disallows them.
 
-isPageFile :: FilePath -> Bool
-isPageFile f = takeExtension f == ".page"
+isPageFile :: FilePath -> GititServerPart Bool
+isPageFile f = do
+  cfg <- getConfig
+  return $ takeExtension f == "." ++ (defaultExtension cfg)
 
 isDiscussPage :: String -> Bool
 isDiscussPage ('@':xs) = isPage xs
 isDiscussPage _ = False
 
-isDiscussPageFile :: FilePath -> Bool
+isDiscussPageFile :: FilePath -> GititServerPart Bool
 isDiscussPageFile ('@':xs) = isPageFile xs
-isDiscussPageFile _ = False
+isDiscussPageFile _ = return False
+
+isNotDiscussPageFile :: FilePath -> GititServerPart Bool
+isNotDiscussPageFile ('@':_) = return False
+isNotDiscussPageFile _ = return True
 
 isSourceCode :: String -> Bool
 isSourceCode path' =
@@ -279,8 +286,8 @@ urlForPage :: String -> String
 urlForPage page = '/' : encString False isUnescapedInURI page
 
 -- | Returns the filestore path of the file containing the page's source.
-pathForPage :: String -> FilePath
-pathForPage page = page <.> "page"
+pathForPage :: String -> String -> FilePath
+pathForPage page ext = page <.> ext
 
 -- | Retrieves a mime type based on file extension.
 getMimeTypeForExtension :: String -> GititServerPart String

--- a/Network/Gitit/Initialize.hs
+++ b/Network/Gitit/Initialize.hs
@@ -154,11 +154,11 @@ createDefaultPages conf = do
           "\n...\n\n"
     -- add front page, help page, and user's guide
     let auth = Author "Gitit" ""
-    createIfMissing fs (frontPage conf <.> "page") auth "Default front page"
+    createIfMissing fs (frontPage conf <.> defaultExtension conf) auth "Default front page"
       $ header ++ welcomecontents
-    createIfMissing fs "Help.page" auth "Default help page"
+    createIfMissing fs ("Help" <.> defaultExtension conf) auth "Default help page"
       $ header ++ helpcontents
-    createIfMissing fs "Gitit User’s Guide.page" auth "User’s guide (README)"
+    createIfMissing fs ("Gitit User's Guide" <.> defaultExtension conf) auth "User's guide (README)"
       $ header ++ usersguidecontents
 
 createIfMissing :: FileStore -> FilePath -> Author -> Description -> String -> IO ()

--- a/Network/Gitit/Types.hs
+++ b/Network/Gitit/Types.hs
@@ -58,6 +58,8 @@ data Config = Config {
   repositoryType       :: FileStoreType,
   -- | Default page markup type for this wiki
   defaultPageType      :: PageType,
+  -- | Default file extension for pages in this wiki
+  defaultExtension     :: String,
   -- | How to handle LaTeX math in pages?
   mathMethod           :: MathMethod,
   -- | Treat as literate haskell by default?

--- a/data/default.conf
+++ b/data/default.conf
@@ -55,6 +55,10 @@ static-dir: static
 # css, and images).  If it does not exist, gitit will create it
 # and populate it with required scripts, stylesheets, and images.
 
+default-extension: page
+# files in the repository path must have this extension in order
+# to be recognized as Wiki pages
+
 default-page-type: Markdown
 # specifies the type of markup used to interpret pages in the wiki.
 # Possible values are Markdown, RST, LaTeX, HTML, Markdown+LHS, RST+LHS,


### PR DESCRIPTION
These changes allow a user to change page extension from `page` to some other string (like `md`) in the configuration file, per #298.

I think I've found all the places where `page` was hardcoded and adjusted functions accordingly, but there are still at least two problems I could use help with:

- It's hard to see an easy way to get rid of the hard-coded `page` extensions in the `Feed` module, so I've left that one in place even though it means links in the feed likely won't work.
- For some reason the `createIfMissing` function in `Initialize` doesn't seem to create the appropriate files with the newly configured extension, perhaps because it's using the default `Config` somewhere in the chain instead of reading config from file?

I've tested locally and the other functions that I changed still seem to behave as expected.