### PR TITLE
Fixed failure when loading the Subst plugin. Control.Monad.CatchIO is

### DIFF
--- a/plugins/Subst.hs
+++ b/plugins/Subst.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
 -- Usage:  a paragraph containing just [My page](!subst)
 -- will be replaced by the contents of My page.
 --
@@ -6,7 +8,7 @@
 
 module Subst (plugin) where
 
-import Control.Monad.CatchIO (try)
+import "MonadCatchIO-mtl" Control.Monad.CatchIO (try)
 import Data.FileStore (FileStoreError, retrieve)
 import Text.Pandoc (def, readMarkdown)
 import Network.Gitit.ContentTransformer (inlinesToString)


### PR DESCRIPTION
Running:
gitit -f my.conf

Where my.conf contains the line:
plugins: /some/path/to/gitit/plugins/Subst.hs

I get the following error:
Ambiguous module name `Control.Monad.CatchIO': it was found in multiple packages: MonadCatchIO-transformers-0.3.1.0 MonadCatchIO-mtl-0.3.1.0

This change uses the PackageImports language extension to resolve this.
