### PR TITLE
Add support for `mediawiki` as a page format.

### DIFF
--- a/Network/Gitit/ContentTransformer.hs
+++ b/Network/Gitit/ContentTransformer.hs
@@ -671,13 +671,14 @@ readerFor pt lhs =
                                               $ readerExtensions def
                                          else readerExtensions def }
   in case pt of
-       RST      -> readRST defPS
-       Markdown -> readMarkdown defPS
-       LaTeX    -> readLaTeX defPS
-       HTML     -> readHtml defPS
-       Textile  -> readTextile defPS
-       Org      -> readOrg defPS
-       DocBook  -> readDocBook defPS
+       RST        -> readRST defPS
+       Markdown   -> readMarkdown defPS
+       LaTeX      -> readLaTeX defPS
+       HTML       -> readHtml defPS
+       Textile    -> readTextile defPS
+       Org        -> readOrg defPS
+       DocBook    -> readDocBook defPS
+       MediaWiki  -> readMediaWiki defPS
 
 wikiLinksTransform :: Pandoc -> PluginM Pandoc
 wikiLinksTransform pandoc

--- a/Network/Gitit/Types.hs
+++ b/Network/Gitit/Types.hs
@@ -39,7 +39,8 @@ import Text.HTML.TagSoup.Entity (lookupEntity)
 import Data.Char (isSpace)
 import Network.OAuth.OAuth2
 
-data PageType = Markdown | RST | LaTeX | HTML | Textile | Org | DocBook
+data PageType = Markdown | RST | LaTeX | HTML | Textile | Org | DocBook 
+              | MediaWiki
                 deriving (Read, Show, Eq)
 
 data FileStoreType = Git | Darcs | Mercurial deriving Show

--- a/Network/Gitit/Util.hs
+++ b/Network/Gitit/Util.hs
@@ -101,6 +101,7 @@ parsePageType s =
        "textile"      -> (Textile,False)
        "latex"        -> (LaTeX,False)
        "latex+lhs"    -> (LaTeX,True)
+       "mediawiki"    -> (MediaWiki,False)
        x              -> error $ "Unknown page type: " ++ x
 
 encUrl :: String -> String


### PR DESCRIPTION
Allow use of _mediawiki_ as an input page format. This is pretty handy when migrating from
media wiki. 

Tested simple cases and seems to work pretty well for the actual markup convertion.
