### PR TITLE
look for files in cache-dir as well as static-dir

### DIFF
--- a/Network/Gitit/Export.hs
+++ b/Network/Gitit/Export.hs
@@ -243,18 +243,19 @@ respondPDF useBeamer page old_pndc = fixURLs page old_pndc >>= \pndc -> do
                         (toResponse noHtml) {rsBody = pdfBS}
 
 -- | When we create a PDF or ODT from a Gitit page, we need to fix the URLs of any
--- images on the page. Those URLs will often be relative to the staticDir, but the
+-- images on the page. Those URLs will often be relative to the staticDir or cacheDir, but the
 -- PDF or ODT processor only understands paths relative to the working directory.
 --
 -- Because the working directory will not in general be the root of the gitit instance
 -- at the time the Pandoc is fed to e.g. pdflatex, this function replaces the URLs of
--- images in the staticDir with their correct absolute file path.
+-- images in the staticDir or cacheDir with their correct absolute file path.
 fixURLs :: String -> Pandoc -> GititServerPart Pandoc
 fixURLs page pndc = do
     cfg <- getConfig
     defaultStatic <- liftIO $ getDataFileName $ "data" </> "static"
 
     let static = staticDir cfg
+        cache  = cacheDir  cfg
     let repoPath = repositoryPath cfg
 
     let go (Image ils (url, title)) = do
@@ -266,11 +267,14 @@ fixURLs page pndc = do
         fixURL url       = resolve $ takeDirectory page </> url
 
         resolve p = do
+           cp <- doesFileExist $ cache  </> p
            sp <- doesFileExist $ static </> p
            dsp <- doesFileExist $ defaultStatic </> p
            return (if sp then static </> p
-                   else (if dsp then defaultStatic </> p
-                         else repoPath </> p))
+                    else (if dsp then defaultStatic </> p
+                      else (if cp then cache </> p
+                        else repoPath </> p)))
+
     liftIO $ bottomUpM go pndc
 
 exportFormats :: Config -> [(String, String -> Pandoc -> Handler)]

--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -204,6 +204,7 @@ uploadFile = withData $ \(params :: Params) -> do
                       if e == NotFound
                          then return False
                          else E.throwIO e >> return True
+  let inCacheDir  = cacheDir  cfg `isPrefixOf` (repositoryPath cfg </> wikiname)
   let inStaticDir = staticDir cfg `isPrefixOf` (repositoryPath cfg </> wikiname)
   let inTemplatesDir = templatesDir cfg `isPrefixOf` (repositoryPath cfg </> wikiname)
   let dirs' = splitDirectories $ takeDirectory wikiname
@@ -213,6 +214,7 @@ uploadFile = withData $ \(params :: Params) -> do
                     "Description cannot be empty.")
                  , (".." `elem` dirs', "Wikiname cannot contain '..'")
                  , (null origPath, "File not found.")
+                 , (inCacheDir,  "Destination is inside cache directory.")
                  , (inStaticDir,  "Destination is inside static directory.")
                  , (inTemplatesDir,  "Destination is inside templates directory.")
                  , (not overwrite && exists, "A file named '" ++ wikiname ++

--- a/Network/Gitit/Initialize.hs
+++ b/Network/Gitit/Initialize.hs
@@ -19,6 +19,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 module Network.Gitit.Initialize ( initializeGititState
                                 , recompilePageTemplate
                                 , compilePageTemplate
+                                , createCacheIfMissing
                                 , createStaticIfMissing
                                 , createRepoIfMissing
                                 , createDefaultPages
@@ -85,6 +86,11 @@ compilePageTemplate tempsDir = do
   case T.getStringTemplate "page" combinedGroup of
         Just t    -> return t
         Nothing   -> error "Could not get string template"
+
+createCacheIfMissing :: Config -> IO ()
+createCacheIfMissing c = do
+  createDirectoryIfMissing True $ cacheDir c
+  createDirectoryIfMissing True $ cacheDir c </> "img"
 
 -- | Create templates dir if it doesn't exist.
 createTemplateIfMissing :: Config -> IO ()

--- a/plugins/Dot.hs
+++ b/plugins/Dot.hs
@@ -33,7 +33,7 @@ transformBlock (CodeBlock (_, classes, namevals) contents) | "dot" `elem` classe
                                 Nothing   -> ([], uniqueName contents ++ ".png")
   liftIO $ do
     (ec, _out, err) <- readProcessWithExitCode "dot" ["-Tpng", "-o",
-                         staticDir cfg </> "img" </> outfile] contents
+                         cacheDir cfg </> "img" </> outfile] contents
     if ec == ExitSuccess
        then return $ Para [Image name ("/img" </> outfile, "")]
        else error $ "dot returned an error status: " ++ err

--- a/plugins/ImgTex.hs
+++ b/plugins/ImgTex.hs
@@ -63,7 +63,7 @@ transformBlock (CodeBlock (_, classes, namevals) contents)
     system $ "latex " ++ outfile ++ ".tex > /dev/null"
     setCurrentDirectory curr
     system $ "dvipng -T tight -bd 1000 -freetype0 -Q 5 --gamma 1.3 " ++
-              (tmpdir </> outfile <.> "dvi") ++ " -o " ++ (staticDir cfg </> "img" </> outfile)
+              (tmpdir </> outfile <.> "dvi") ++ " -o " ++ (cacheDir cfg </> "img" </> outfile)
     return $ Para [Image name ("/img" </> outfile, "")]
 transformBlock x = return x
 


### PR DESCRIPTION
I do a lot of editing Dot blocks in the browser preview page, which was causing a buildup of images in the static/img dir. This changes plugins to put images in cache-dir instead, and changes gitit to look there first. It assumes that dot diagrams should be drawn on-the-fly, but could be modified to save the image in the static-dir when an explicit name is given, if that's an important use case. I have another pull request that builds on this to make clickable SVG dot diagrams.