### PR TITLE
Clickable svg dot diagrams

### DIFF
--- a/Network/Gitit/Export.hs
+++ b/Network/Gitit/Export.hs
@@ -243,18 +243,19 @@ respondPDF useBeamer page old_pndc = fixURLs page old_pndc >>= \pndc -> do
                         (toResponse noHtml) {rsBody = pdfBS}
 
 -- | When we create a PDF or ODT from a Gitit page, we need to fix the URLs of any
--- images on the page. Those URLs will often be relative to the staticDir, but the
+-- images on the page. Those URLs will often be relative to the staticDir or cacheDir, but the
 -- PDF or ODT processor only understands paths relative to the working directory.
 --
 -- Because the working directory will not in general be the root of the gitit instance
 -- at the time the Pandoc is fed to e.g. pdflatex, this function replaces the URLs of
--- images in the staticDir with their correct absolute file path.
+-- images in the staticDir or cacheDir with their correct absolute file path.
 fixURLs :: String -> Pandoc -> GititServerPart Pandoc
 fixURLs page pndc = do
     cfg <- getConfig
     defaultStatic <- liftIO $ getDataFileName $ "data" </> "static"
 
     let static = staticDir cfg
+        cache  = cacheDir  cfg
     let repoPath = repositoryPath cfg
 
     let go (Image ils (url, title)) = do
@@ -266,11 +267,14 @@ fixURLs page pndc = do
         fixURL url       = resolve $ takeDirectory page </> url
 
         resolve p = do
+           cp <- doesFileExist $ cache  </> p
            sp <- doesFileExist $ static </> p
            dsp <- doesFileExist $ defaultStatic </> p
            return (if sp then static </> p
-                   else (if dsp then defaultStatic </> p
-                         else repoPath </> p))
+                    else (if dsp then defaultStatic </> p
+                      else (if cp then cache </> p
+                        else repoPath </> p)))
+
     liftIO $ bottomUpM go pndc
 
 exportFormats :: Config -> [(String, String -> Pandoc -> Handler)]

--- a/Network/Gitit/Handlers.hs
+++ b/Network/Gitit/Handlers.hs
@@ -204,6 +204,7 @@ uploadFile = withData $ \(params :: Params) -> do
                       if e == NotFound
                          then return False
                          else E.throwIO e >> return True
+  let inCacheDir  = cacheDir  cfg `isPrefixOf` (repositoryPath cfg </> wikiname)
   let inStaticDir = staticDir cfg `isPrefixOf` (repositoryPath cfg </> wikiname)
   let inTemplatesDir = templatesDir cfg `isPrefixOf` (repositoryPath cfg </> wikiname)
   let dirs' = splitDirectories $ takeDirectory wikiname
@@ -213,6 +214,7 @@ uploadFile = withData $ \(params :: Params) -> do
                     "Description cannot be empty.")
                  , (".." `elem` dirs', "Wikiname cannot contain '..'")
                  , (null origPath, "File not found.")
+                 , (inCacheDir,  "Destination is inside cache directory.")
                  , (inStaticDir,  "Destination is inside static directory.")
                  , (inTemplatesDir,  "Destination is inside templates directory.")
                  , (not overwrite && exists, "A file named '" ++ wikiname ++

--- a/Network/Gitit/Initialize.hs
+++ b/Network/Gitit/Initialize.hs
@@ -19,6 +19,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 module Network.Gitit.Initialize ( initializeGititState
                                 , recompilePageTemplate
                                 , compilePageTemplate
+                                , createCacheIfMissing
                                 , createStaticIfMissing
                                 , createRepoIfMissing
                                 , createDefaultPages
@@ -85,6 +86,11 @@ compilePageTemplate tempsDir = do
   case T.getStringTemplate "page" combinedGroup of
         Just t    -> return t
         Nothing   -> error "Could not get string template"
+
+createCacheIfMissing :: Config -> IO ()
+createCacheIfMissing c = do
+  createDirectoryIfMissing True $ cacheDir c
+  createDirectoryIfMissing True $ cacheDir c </> "img"
 
 -- | Create templates dir if it doesn't exist.
 createTemplateIfMissing :: Config -> IO ()

--- a/gitit.hs
+++ b/gitit.hs
@@ -83,6 +83,7 @@ main = do
 
   -- setup the page repository, template, and static files, if they don't exist
   createRepoIfMissing conf
+  createCacheIfMissing conf
   createStaticIfMissing conf
   createTemplateIfMissing conf
 

--- a/plugins/Dot.hs
+++ b/plugins/Dot.hs
@@ -8,10 +8,11 @@ module Dot (plugin) where
 -- ~~~
 --
 -- The "dot" executable must be in the path.
--- The generated png file will be saved in the static img directory.
--- If no name is specified, a unique name will be generated from a hash
--- of the file contents.
+-- The generated svg file will be cached in the cache directory.
+-- A unique name will be generated from a hash of the file contents,
+-- prefixed with the 'name' attribute if one is given.
 
+import Data.Maybe (fromMaybe)
 import Network.Gitit.Interface
 import System.Process (readProcessWithExitCode)
 import System.Exit (ExitCode(ExitSuccess))
@@ -19,7 +20,9 @@ import System.Exit (ExitCode(ExitSuccess))
 import Data.ByteString.Lazy.UTF8 (fromString)
 -- from the SHA package on HackageDB:
 import Data.Digest.Pure.SHA (sha1, showDigest)
+import System.Directory (doesFileExist)
 import System.FilePath ((</>))
+import Control.Monad (unless)
 import Control.Monad.Trans (liftIO)
 
 plugin :: Plugin
@@ -28,18 +31,18 @@ plugin = mkPageTransformM transformBlock
 transformBlock :: Block -> PluginM Block
 transformBlock (CodeBlock (_, classes, namevals) contents) | "dot" `elem` classes = do
   cfg <- askConfig
-  let (name, outfile) =  case lookup "name" namevals of
-                                Just fn   -> ([Str fn], fn ++ ".png")
-                                Nothing   -> ([], uniqueName contents ++ ".png")
-  liftIO $ do
-    (ec, _out, err) <- readProcessWithExitCode "dot" ["-Tpng", "-o",
-                         staticDir cfg </> "img" </> outfile] contents
-    if ec == ExitSuccess
-       then return $ Para [Image name ("/img" </> outfile, "")]
-       else error $ "dot returned an error status: " ++ err
+  let prefix  = fromMaybe "dot" $ lookup "name" namevals
+      outfile = cacheDir cfg </> prefix ++ "-" ++ uniqueName contents ++ ".svg"
+      dotargs = ["-Tsvg", "-o", outfile]
+  cached <- liftIO $ doesFileExist outfile
+  unless cached $ do
+    (ec, _out, err) <- liftIO $ readProcessWithExitCode "dot" dotargs contents
+    -- TODO fix so it doesn't crash the wiki with an error!
+    unless (ec == ExitSuccess) $ error $ "dot returned an error status: " ++ err
+  svg <- liftIO $ readFile outfile
+  return $ RawBlock (Format "html") svg
 transformBlock x = return x
 
 -- | Generate a unique filename given the file's contents.
 uniqueName :: String -> String
 uniqueName = showDigest . sha1 . fromString
-

--- a/plugins/ImgTex.hs
+++ b/plugins/ImgTex.hs
@@ -63,7 +63,7 @@ transformBlock (CodeBlock (_, classes, namevals) contents)
     system $ "latex " ++ outfile ++ ".tex > /dev/null"
     setCurrentDirectory curr
     system $ "dvipng -T tight -bd 1000 -freetype0 -Q 5 --gamma 1.3 " ++
-              (tmpdir </> outfile <.> "dvi") ++ " -o " ++ (staticDir cfg </> "img" </> outfile)
+              (tmpdir </> outfile <.> "dvi") ++ " -o " ++ (cacheDir cfg </> "img" </> outfile)
     return $ Para [Image name ("/img" </> outfile, "")]
 transformBlock x = return x
 


### PR DESCRIPTION
Includes the changes from my req-cachedir branch, plus changes Dot.hs to do SVG diagrams instead of PNG. That's nice beacuse it lets you put `href` elements in the node and edge labels and they come out as clickable links.