### PR TITLE
Add plugin-dir to config file and look for plugins relative to it

### DIFF
--- a/Network/Gitit/Config.hs
+++ b/Network/Gitit/Config.hs
@@ -95,6 +95,7 @@ extractConfig cp = do
       cfLogFile <- get cp "DEFAULT" "log-file"
       cfLogLevel <- get cp "DEFAULT" "log-level"
       cfStaticDir <- get cp "DEFAULT" "static-dir"
+      cfPluginDir <- get cp "DEFAULT" "plugin-dir"
       cfPlugins <- get cp "DEFAULT" "plugins"
       cfTableOfContents <- get cp "DEFAULT" "table-of-contents"
       cfMaxUploadSize <- get cp "DEFAULT" "max-upload-size"
@@ -188,6 +189,7 @@ extractConfig cp = do
                                         then read levelString
                                         else error $ "Invalid log-level.\nLegal values are: " ++ intercalate ", " levels
         , staticDir            = cfStaticDir
+        , pluginDir            = cfPluginDir
         , pluginModules        = splitCommaList cfPlugins
         , tableOfContents      = cfTableOfContents
         , maxUploadSize        = readSize "max-upload-size" cfMaxUploadSize

--- a/Network/Gitit/Initialize.hs
+++ b/Network/Gitit/Initialize.hs
@@ -20,6 +20,7 @@ module Network.Gitit.Initialize ( initializeGititState
                                 , recompilePageTemplate
                                 , compilePageTemplate
                                 , createStaticIfMissing
+                                , createPluginIfMissing
                                 , createRepoIfMissing
                                 , createDefaultPages
                                 , createTemplateIfMissing )
@@ -47,7 +48,8 @@ initializeGititState :: Config -> IO ()
 initializeGititState conf = do
   let userFile' = userFile conf
       pluginModules' = pluginModules conf
-  plugins' <- loadPlugins pluginModules'
+      plugindir = pluginDir conf
+  plugins' <- loadPlugins plugindir pluginModules'
 
   userFileExists <- doesFileExist userFile'
   users' <- if userFileExists
@@ -169,6 +171,9 @@ createIfMissing fs p a comm cont = do
        Right _ -> logM "gitit" WARNING ("Added " ++ p ++ " to repository")
        Left ResourceExists -> return ()
        Left e              -> throwIO e >> return ()
+
+createPluginIfMissing :: Config -> IO ()
+createPluginIfMissing conf = createDirectoryIfMissing True $ pluginDir conf
 
 -- | Create static directory unless it exists.
 createStaticIfMissing :: Config -> IO ()

--- a/Network/Gitit/Types.hs
+++ b/Network/Gitit/Types.hs
@@ -124,6 +124,8 @@ data Config = Config {
   logLevel             :: Priority,
   -- | Path of static directory
   staticDir            :: FilePath,
+  -- | Where to search for plugins by name
+  pluginDir            :: FilePath,
   -- | Names of plugin modules to load
   pluginModules        :: [String],
   -- | Show table of contents on each page?

--- a/data/default.conf
+++ b/data/default.conf
@@ -55,6 +55,9 @@ static-dir: static
 # css, and images).  If it does not exist, gitit will create it
 # and populate it with required scripts, stylesheets, and images.
 
+plugin-dir: plugins
+# where to search for plugins given by relative filename
+
 default-page-type: Markdown
 # specifies the type of markup used to interpret pages in the wiki.
 # Possible values are Markdown, RST, LaTeX, HTML, Markdown+LHS, RST+LHS,

--- a/gitit.hs
+++ b/gitit.hs
@@ -84,6 +84,7 @@ main = do
   -- setup the page repository, template, and static files, if they don't exist
   createRepoIfMissing conf
   createStaticIfMissing conf
+  createPluginIfMissing conf
   createTemplateIfMissing conf
 
   -- initialize state


### PR DESCRIPTION
This adds plugin-dir to the config file and looks up plugins relative to it. It doesn't make a big difference in any current gitit code, but I'm helps with a plugin I'm writing called External (sorry for the separate pull request if that's not the normal way to do them).