### PR TITLE
Add External plugin

### DIFF
--- a/Network/Gitit/Config.hs
+++ b/Network/Gitit/Config.hs
@@ -95,6 +95,7 @@ extractConfig cp = do
       cfLogFile <- get cp "DEFAULT" "log-file"
       cfLogLevel <- get cp "DEFAULT" "log-level"
       cfStaticDir <- get cp "DEFAULT" "static-dir"
+      cfPluginDir <- get cp "DEFAULT" "plugin-dir"
       cfPlugins <- get cp "DEFAULT" "plugins"
       cfTableOfContents <- get cp "DEFAULT" "table-of-contents"
       cfMaxUploadSize <- get cp "DEFAULT" "max-upload-size"
@@ -188,6 +189,7 @@ extractConfig cp = do
                                         then read levelString
                                         else error $ "Invalid log-level.\nLegal values are: " ++ intercalate ", " levels
         , staticDir            = cfStaticDir
+        , pluginDir            = cfPluginDir
         , pluginModules        = splitCommaList cfPlugins
         , tableOfContents      = cfTableOfContents
         , maxUploadSize        = readSize "max-upload-size" cfMaxUploadSize

--- a/Network/Gitit/Initialize.hs
+++ b/Network/Gitit/Initialize.hs
@@ -20,6 +20,7 @@ module Network.Gitit.Initialize ( initializeGititState
                                 , recompilePageTemplate
                                 , compilePageTemplate
                                 , createStaticIfMissing
+                                , createPluginIfMissing
                                 , createRepoIfMissing
                                 , createDefaultPages
                                 , createTemplateIfMissing )
@@ -47,7 +48,8 @@ initializeGititState :: Config -> IO ()
 initializeGititState conf = do
   let userFile' = userFile conf
       pluginModules' = pluginModules conf
-  plugins' <- loadPlugins pluginModules'
+      plugindir = pluginDir conf
+  plugins' <- loadPlugins plugindir pluginModules'
 
   userFileExists <- doesFileExist userFile'
   users' <- if userFileExists
@@ -169,6 +171,9 @@ createIfMissing fs p a comm cont = do
        Right _ -> logM "gitit" WARNING ("Added " ++ p ++ " to repository")
        Left ResourceExists -> return ()
        Left e              -> throwIO e >> return ()
+
+createPluginIfMissing :: Config -> IO ()
+createPluginIfMissing conf = createDirectoryIfMissing True $ pluginDir conf
 
 -- | Create static directory unless it exists.
 createStaticIfMissing :: Config -> IO ()

--- a/Network/Gitit/Plugin/External.hs
+++ b/Network/Gitit/Plugin/External.hs
@@ -1,0 +1,212 @@
+module Network.Gitit.Plugin.External
+  ( plugin
+  , mkPlugin
+  , Plugin
+  , allArgs
+  , askFile
+  , link2path
+  ) where
+
+import Control.Monad.IO.Class
+import Data.List
+import Data.List.Split
+import Data.Maybe
+import Network.Gitit.Interface
+import System.Exit
+import System.FilePath
+import System.FilePath.Canonical
+import System.Process
+import Paths_gitit (getDataFileName)
+
+{- Passes text to an external script as stdin
+ - and returns with the script's stdout
+ - (or debugging info if there's an error)
+ -}
+eval :: FilePath -> [String] -> String -> IO String
+eval "" _ _ = return "ERROR: missing 'bin' attribute"
+eval bin args txt = do
+  (code, out, err) <- readProcessWithExitCode bin args txt
+  return $ if code == ExitSuccess
+    then out
+    else unlines
+      [ "ERROR:  " ++ show bin ++ " returned " ++ show code
+      , "args:   " ++ show args
+      , "stdin:  " ++ show txt
+      , "stdout: " ++ show out
+      , "stderr: " ++ show err
+      ]
+
+{- Takes a format string and some text, and
+ - wraps the text in the corresponding Pandoc Block
+ -}
+wrap :: String -> String -> Block
+wrap "html" txt = RawBlock (Format "html") txt
+wrap "csv"  txt = CodeBlock ("", ["csv"], []) txt
+wrap "list" txt = BulletList [map (\s -> Plain [Str s]) $ lines txt]
+wrap "para" txt = Para  [Str txt]
+wrap _      txt = Plain [Str txt]
+
+mkFlags :: [String] -> [(String, [String])] -> [String]
+mkFlags ask usr = concatMap flagify $ screen usr
+  where
+    screen = filter (\(k,_) -> elem k ask)
+    flagify (k, vs) = ("--" ++ k):vs
+
+-- asks for the plugin data available from gitit and
+-- formats it as command line args for external scripts
+-- also takes a predicate for filtering which optional args to pass
+-- TODO clean this up and de-duplicate
+argList :: [String] -> [(String, String)] -> PluginM [String]
+argList ask usr = do
+  c <- askConfig
+  m <- askMeta
+  r <- askRequest
+  configPlugins    <- liftIO $ canonical $ pluginDir      c
+  configStatic     <- liftIO $ canonical $ staticDir      c
+  configTemplates  <- liftIO $ canonical $ templatesDir   c
+  configCache      <- liftIO $ canonical $ cacheDir       c
+  configRepository <- liftIO $ canonical $ repositoryPath c
+  defaultPlugins   <- liftIO $ getDataFileName "plugins"
+  defaultStatic    <- liftIO $ getDataFileName $ "data" </> "static"
+  defaultTemplates <- liftIO $ getDataFileName $ "data" </> "templates"
+  let
+    sndSingletons = map (\(k,v) -> (k,[v]))
+    usrFlags  = sndSingletons usr
+    metaFlags = sndSingletons m
+    reqFlags  = [("uri", [rqUri r])]
+    cfgFlags  =
+      [ ("cache-dir"      , [canonicalFilePath configCache                      ])
+      , ("repository-path", [canonicalFilePath configRepository                 ])
+      , ("plugin-dir"     , [canonicalFilePath configPlugins  , defaultPlugins  ])
+      , ("static-dir"     , [canonicalFilePath configStatic   , defaultStatic   ])
+      , ("templates-dir"  , [canonicalFilePath configTemplates, defaultTemplates])
+      ]
+    askedArgs = concat [usrFlags, metaFlags, cfgFlags, reqFlags]
+    adhocArgs = [a | a <- ask ++ map fst usr, a `notElem` ["bin", "fmt", "nfo"]]
+    finalArgs = mkFlags adhocArgs askedArgs
+  return finalArgs
+
+allArgs :: [String]
+allArgs =
+  [ "repository-path"
+  , "templates-dir"
+  , "static-dir"
+  , "plugin-dir"
+  , "cache-dir"
+  , "uri"
+  ]
+
+{- This renders generic "external" codeblocks using whatever
+ - command you want. The 'bin' attribute is required,
+ - but 'fmt' defaults to "plain" (plain text) and 'ask' to [].
+ -
+ - Other fmt options are:
+ -   "para" for plain text as a paragraph
+ -   "csv"  for a table of comma-separated values
+ -   "list" for a bullet list
+ -   "html" for raw html
+ -
+ - 'ask' should be a whitespace-separated list of args
+ - you'd like this plugin to pass on to your script.
+ - The options are:
+ -   repository-path
+ -   templates-dir
+ -   static-dir
+ -   plugin-dir
+ -   cache-dir
+ -   uri
+ -
+ - Here's how you might use it:
+ -
+ - > ~~~ { .external bin="/path/to/my/binary" fmt="html" ask="uri cache-dir" }
+ - > gitit will run '/path/to/my/binary --uri <page uri> --cache-dir <cache dir>'
+ - > this text will be sent as stdin,
+ - > and then stdout will be wrapped in RawBlock "html"
+ - > ~~~
+ -}
+plugin :: Plugin
+plugin = mkPageTransformM tfm
+  where
+    tfm :: Block -> PluginM Block
+    tfm (CodeBlock (_, cs, as) txt) | "external" `elem` cs = do
+      let bin = fromMaybe "" $ lookup "bin" as
+          fmt = fromMaybe "" $ lookup "fmt" as
+          nfo = fromMaybe "" $ lookup "nfo" as -- TODO rename nfo to ask?
+      args <- argList (words nfo) as
+      bin' <- findBinary bin
+      out  <- liftIO $ eval bin' args txt
+      return $ wrap fmt out
+    tfm x = return x
+
+-- TODO get this to work with plugins in the ghc data dir too?
+-- TODO and in whatever logic parses the config file
+findBinary :: FilePath -> PluginM FilePath
+findBinary b = if "/" `isPrefixOf` b
+                then return b
+                else do
+                  cfg <- askConfig
+                  return $ pluginDir cfg </> b
+
+{- This lets you build custom external plugins
+ - to handle specific block classes. That way you don't
+ - have to write the 'bin' over and over.
+ - It works the same way as above except you're
+ - hard-coding the attributes.
+ -
+ - For example, this is a complete CustomPlugin.hs:
+ -
+ - > module CustomPlugin (plugin) where
+ - > import Gitit.Network.Plugin.External (mkPlugin)
+ - > plugin = mkPlugin "custom" "html" "/path/to/my/binary" ["uri"]
+ -
+ - And here's how you might use it:
+ -
+ - > ~~~ { .custom }
+ - > gitit will run '/path/to/my/binary --uri <page uri>'
+ - > this text will be sent as stdin
+ - > and then stdout will be wrapped in a RawBlock "html"
+ - > ~~~
+ -}
+mkPlugin :: String -> String -> FilePath -> [String] -> Plugin
+mkPlugin cls fmt bin ask = mkPageTransformM tfm
+  where
+    tfm :: Block -> PluginM Block
+    tfm (CodeBlock (_, cs, as) txt) | cls `elem` cs = do
+      args <- argList ask as
+      name <- findBinary bin
+      out  <- liftIO $ eval name args txt
+      return $ wrap fmt out
+    tfm x = return x
+
+-- TODO can you get the raw page path from a Page object somewhere?
+--      looks like it from the debug output...
+
+uri2path :: String -> FilePath
+uri2path uri
+  = intercalate [pathSeparator]
+  $ filter (/= "")                        -- remove blanks
+  $ filter (\s -> not $ isPrefixOf "_" s) -- remove _edit etc.
+  $ splitOn [pathSeparator] uri
+
+-- returns the path to the .page file associated with a request
+-- TODO should it find stuff in the ghc data dir too?
+askFile :: PluginM FilePath
+askFile = do
+  cfg <- askConfig
+  req <- askRequest
+  let p1 = repositoryPath cfg
+      p2 = uri2path $ rqUri req
+      p  = joinPath [p1, p2]
+  return p
+
+-- takes an absolute or relative gitit link
+-- and makes it into a file path relative to the running program
+link2path :: String -> PluginM FilePath
+link2path lnk = do
+  cfg <- askConfig
+  pfp <- askFile
+  -- if it starts with "/", the link is relative to the repository
+  -- otherwise, it's relative to the requested page
+  return $ joinPath $ if "/" `isPrefixOf` lnk
+    then [repositoryPath cfg, dropWhile (== '/') lnk]
+    else [takeDirectory pfp, lnk]

--- a/Network/Gitit/Types.hs
+++ b/Network/Gitit/Types.hs
@@ -124,6 +124,8 @@ data Config = Config {
   logLevel             :: Priority,
   -- | Path of static directory
   staticDir            :: FilePath,
+  -- | Where to search for plugins by name
+  pluginDir            :: FilePath,
   -- | Names of plugin modules to load
   pluginModules        :: [String],
   -- | Show table of contents on each page?

--- a/data/default.conf
+++ b/data/default.conf
@@ -55,6 +55,9 @@ static-dir: static
 # css, and images).  If it does not exist, gitit will create it
 # and populate it with required scripts, stylesheets, and images.
 
+plugin-dir: plugins
+# where to search for plugins given by relative filename
+
 default-page-type: Markdown
 # specifies the type of markup used to interpret pages in the wiki.
 # Possible values are Markdown, RST, LaTeX, HTML, Markdown+LHS, RST+LHS,

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -126,11 +126,12 @@ Library
                      Network.Gitit.Plugins, Network.Gitit.Rpxnow,
                      Network.Gitit.Page, Network.Gitit.Feed
   if flag(plugins)
-    exposed-modules: Network.Gitit.Interface
+    exposed-modules: Network.Gitit.Interface, Network.Gitit.Plugin.External
     build-depends:   ghc, ghc-paths
     cpp-options:     -D_PLUGINS
   build-depends:     base >= 3, pandoc >= 1.12.4 && < 1.14,
-                     pandoc-types >= 1.12.3 && < 1.13, filepath, safe
+                     pandoc-types >= 1.12.3 && < 1.13, filepath, safe,
+                     transformers, canonical-filepath
   extensions:        CPP
   if impl(ghc >= 6.12)
     ghc-options:     -Wall -fno-warn-unused-do-bind
@@ -191,7 +192,7 @@ Executable           gitit
   else
     build-depends:   network >= 2 && < 2.6
   if flag(plugins)
-    build-depends:   ghc, ghc-paths
+    build-depends:   ghc, ghc-paths, canonical-filepath
     cpp-options:     -D_PLUGINS
   extensions:        CPP
   if impl(ghc >= 6.12)

--- a/gitit.hs
+++ b/gitit.hs
@@ -84,6 +84,7 @@ main = do
   -- setup the page repository, template, and static files, if they don't exist
   createRepoIfMissing conf
   createStaticIfMissing conf
+  createPluginIfMissing conf
   createTemplateIfMissing conf
 
   -- initialize state

--- a/plugins/BashExample.hs
+++ b/plugins/BashExample.hs
@@ -1,0 +1,11 @@
+module BashExample (plugin) where
+
+import Network.Gitit.Interface       (Plugin)
+import Network.Gitit.Plugin.External (mkPlugin, allArgs)
+
+plugin :: Plugin
+plugin = mkPlugin
+  "bashexample"    -- input block class
+  "html"           -- output block class
+  "bashexample.sh" -- name of script
+  allArgs          -- list of args to pass

--- a/plugins/PerlExample.hs
+++ b/plugins/PerlExample.hs
@@ -1,0 +1,11 @@
+module PerlExample (plugin) where
+
+import Network.Gitit.Interface       (Plugin)
+import Network.Gitit.Plugin.External (mkPlugin, allArgs)
+
+plugin :: Plugin
+plugin = mkPlugin
+  "perlexample"    -- input block class
+  "html"           -- output block class
+  "perlexample.pl" -- name of script
+  allArgs          -- list of args to pass

--- a/plugins/PythonExample.hs
+++ b/plugins/PythonExample.hs
@@ -1,0 +1,11 @@
+module PythonExample (plugin) where
+
+import Network.Gitit.Interface       (Plugin)
+import Network.Gitit.Plugin.External (mkPlugin, allArgs)
+
+plugin :: Plugin
+plugin = mkPlugin
+  "pythonexample"    -- input block class
+  "html"             -- output block class
+  "pythonexample.py" -- name of script
+  allArgs            -- list of args to pass

--- a/plugins/RExample.hs
+++ b/plugins/RExample.hs
@@ -1,0 +1,11 @@
+module RExample (plugin) where
+
+import Network.Gitit.Interface       (Plugin)
+import Network.Gitit.Plugin.External (mkPlugin, allArgs)
+
+plugin :: Plugin
+plugin = mkPlugin
+  "rexample"   -- input block class
+  "html"       -- output block class
+  "rexample.R" -- name of script
+  allArgs      -- list of args to pass

--- a/plugins/bashexample.sh
+++ b/plugins/bashexample.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Example of how to write an external PageTransform plugin in Bash.
+
+echo 'Hello from Bash!'
+echo '<br/>'
+echo 'Your script recieved these args:'
+echo '<br/>'
+echo "$@"
+echo '<br/>'
+echo 'And this text from stdin'
+echo '<br/>'
+while read line; do
+  echo $line
+done

--- a/plugins/perlexample.pl
+++ b/plugins/perlexample.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/perl
+
+# Example of how to write an external PageTransform plugin in Perl.
+
+use strict;
+
+print "Hello from Perl!";
+print "<br/>";
+
+print "Your script recieved these args:";
+print "<br/>";
+print "@ARGV";
+print "<br/>";
+
+print "And this text from stdin:";
+print "<br/>";
+print <STDIN>;
+print "<br/>";
+print "<br/>";

--- a/plugins/pythonexample.py
+++ b/plugins/pythonexample.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python2
+
+# Example of how to write an external PageTransform plugin in Python.
+
+import sys
+
+print 'Hello from Python!'
+print '<br/>'
+
+print 'Your script recieved these args:'
+print '<br/>'
+print sys.argv[1:]
+print '<br/>'
+
+print 'And this text from stdin:'
+print '<br/>'
+print sys.stdin.read()
+print '<br/>'
+print '<br/>'

--- a/plugins/rexample.R
+++ b/plugins/rexample.R
@@ -1,0 +1,17 @@
+#!/usr/bin/Rscript
+
+# Example of how to write an external PageTransform plugin in R.
+
+cat('Hello from R!')
+cat('<br/>')
+
+cat('Your script recieved these args:')
+cat('<br/>')
+cat(commandArgs(trailingOnly=TRUE))
+cat('<br/>')
+
+cat('And this text from stdin:')
+cat('<br/>')
+cat(readLines('stdin'))
+cat('<br/>')
+cat('<br/>')


### PR DESCRIPTION
Includes the changes from my req-plugindir branch plus the External plugin that makes use of them. It pipes code blocks through external programs, which can be things already on your system or scripts you put in the plugin-dir. I'm not sure if the `Network.Gitit.Plugin.External` interface is set up quite right, but it seems to work. This request adds a dependency on the `canonical-filepath` package, plus the Python, Perl, and R interpreters if you want to run the examples.