### PR TITLE
update issues link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -607,7 +607,7 @@ Reporting bugs
 ==============
 
 Bugs may be reported (and feature requests filed) at
-<http://code.google.com/p/gitit/issues/list>.
+<https://github.com/jgm/gitit/issues>.
 
 There is a mailing list for users and developers at
 <http://groups.google.com/group/gitit-discuss>.


### PR DESCRIPTION
According to https://code.google.com/p/gitit/, "This google code site is no longer used. Please see the github site for the source code **and issue tracker**." (emphasis mine)
