### PR TITLE
Fix preview button for modern jQuery.

### DIFF
--- a/data/static/js/preview.js
+++ b/data/static/js/preview.js
@@ -3,7 +3,7 @@ function updatePreviewPane() {
     var url = location.pathname.replace(/_edit\//,"_preview/");
     $.post(
       url,
-      {"raw" : $("#editedText").attr("value")},
+      {"raw" : $("#editedText").val()},
       function(data) {
         $('#previewpane').html(data);
         // Process any mathematics if we're using MathML


### PR DESCRIPTION
Needed for jQuery 2.1.1 anyway (Debian/Ubuntu packages), where
$().attr() *appears* to only read HTML attributes, not DOM attributes.