### PR TITLE
Add missing <br> tag in form on registration page

### DIFF
--- a/Network/Gitit/Authentication.hs
+++ b/Network/Gitit/Authentication.hs
@@ -250,7 +250,7 @@ sharedForm mbUser = withData $ \params -> do
             , label ! [thefor "email"] << "Email (optional, will not be displayed on the Wiki):"
             , br
             , textfield "email" ! [size "20", intAttr "tabindex" 3, value (initField uEmail)]
-            , br
+            , br ! [theclass "req"]
             , textfield "full_name_1" ! [size "20", theclass "req"]
             , br
             , label ! [thefor "password"]

--- a/Network/Gitit/Authentication.hs
+++ b/Network/Gitit/Authentication.hs
@@ -249,8 +249,10 @@ sharedForm mbUser = withData $ \params -> do
             , userNameField
             , label ! [thefor "email"] << "Email (optional, will not be displayed on the Wiki):"
             , br
-            , textfield "email" ! [size "20", intAttr "tabindex" 3, value (initField uEmail)], br
+            , textfield "email" ! [size "20", intAttr "tabindex" 3, value (initField uEmail)]
+            , br
             , textfield "full_name_1" ! [size "20", theclass "req"]
+            , br
             , label ! [thefor "password"]
                     << ("Password (at least 6 characters," ++
                         " including at least one non-letter):")
@@ -537,5 +539,3 @@ currentUser :: Handler
 currentUser = do
   req <- askRq
   ok $ toResponse $ maybe "" toString (getHeader "REMOTE_USER" req)
-
-


### PR DESCRIPTION
The form on the non-templated `/_register` page is missing a `<br>` before the `password` text input.

I noticed this when attempting to apply a different style to my site.

See image below for an example of the impact this issue causes for non default css:

![screen shot 2015-06-23 at 12 16 07 am](https://cloud.githubusercontent.com/assets/428642/8300773/25460660-193d-11e5-8a13-7bd5674c6136.png)
