### PR TITLE
Revert accidental change of singlequotes from UTF-8 to ascii.

### DIFF
--- a/src/Network/Gitit/Initialize.hs
+++ b/src/Network/Gitit/Initialize.hs
@@ -171,7 +171,7 @@ createDefaultPages conf = do
       $ header ++ welcomecontents
     createIfMissing fs ("Help" <.> defaultExtension conf) auth "Default help page"
       $ header ++ helpcontents
-    createIfMissing fs ("Gitit User's Guide" <.> defaultExtension conf) auth "User's guide (README)"
+    createIfMissing fs ("Gitit User’s Guide" <.> defaultExtension conf) auth "User’s guide (README)"
       $ header ++ usersguidecontents
 
 createIfMissing :: FileStore -> FilePath -> Author -> Description -> String -> IO ()


### PR DESCRIPTION
Blame:

d98c60cc Network/Gitit/Initialize.hs (Caleb McDaniel  2014-08-13 16:55:47 -0500 174)