### PR TITLE
Make default theme responsive

### DIFF
--- a/data/static/css/screen.css
+++ b/data/static/css/screen.css
@@ -155,3 +155,40 @@ box-shadow: #555 0 0 10px;
 }
 /* Deal with multiple footnotes one after another; Charuru */
 sup + sup { margin-left: 2px; }
+
+/* Make theme responsive */
+@media (max-width: 768px) {
+  #yui-main {
+    float:none!important;
+    margin-left: 0!important;
+  }
+  #maincol {
+    margin-left: 0!important;
+  }
+  #sidebar {
+    width: 100%;
+    float: none;
+  }
+  #logo {
+    float: left;
+    margin-right:5%;
+    margin-top: 12px;
+    width: 30%;
+  }
+  .sitenav {
+    float: left;
+    margin-right: 5%;
+    width: 30%;
+  }
+  .pageTools {
+    float: right;
+    width: 30%
+  }
+}
+@media (max-device-width: 568px) {
+  #logo, .sitenav, .pageTools {
+    float: none;
+    width: 100%;
+  }
+}
+

--- a/data/templates/page.st
+++ b/data/templates/page.st
@@ -3,6 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     $if(feed)$
     <link href="$base$/_feed/" type="application/atom+xml" rel="alternate" title="$wikititle$" />
     <link href="$base$/_feed$pageUrl$" type="application/atom+xml" rel="alternate" title="$wikititle$ - $pagetitle$" />


### PR DESCRIPTION
This commit makes the default theme responsive. For smaller browsers, it
will move the sidebar below the main content div and make the sidebar
three columns. On phones, it will also collapse the sidebar into a
single column.

Fixes #450