### PR TITLE
Use primary GitHub email rather than just the first

### DIFF
--- a/src/Network/Gitit/Authentication/Github.hs
+++ b/src/Network/Gitit/Authentication/Github.hs
@@ -67,7 +67,7 @@ getGithubUser ghConfig githubCallbackPars githubState =
                             (\githubUserMail -> do
                                        let gitLogin = gLogin githubUser
                                        user <- mkUser (unpack gitLogin)
-                                                   (unpack $ email $ head githubUserMail)
+                                                   (unpack $ email $ head (filter primary githubUserMail))
                                                    "none"
                                        let mbOrg = org ghConfig
                                        case mbOrg of
@@ -117,11 +117,13 @@ instance FromJSON GithubUser where
     parseJSON _ = mzero
 
 data GithubUserMail = GithubUserMail { email :: Text
+                                     , primary :: Bool
                              } deriving (Show, Eq)
 
 instance FromJSON GithubUserMail where
     parseJSON (Object o) = GithubUserMail
                            <$> o .: "email"
+                           <*> o .: "primary"
     parseJSON _ = mzero
 
 sToBS :: String -> BS.ByteString


### PR DESCRIPTION
The order in which user emails are returned via the GitHub API is not specified, so the first may not be the one that the user prefers, i.e. the so-called "primary" email.  To fix this problem, we eliminate all emails except for the one marked as "primary".