### PR TITLE
Cosmetic fixes for better user experience

### DIFF
--- a/data/templates/content.st
+++ b/data/templates/content.st
@@ -1,6 +1,6 @@
 <div id="content">
   $if(revision)$
-    <h2 class="revision">Revision $revision$</h2>
+    <h2 class="revision">Revision $revision$ (click the page title to view the current version)</h2>
   $endif$
   <h1 class="pageTitle"><a href="$base$$pageUrl$">$pagetitle$</a></h1>
   $if(messages)$

--- a/src/Network/Gitit/Handlers.hs
+++ b/src/Network/Gitit/Handlers.hs
@@ -537,7 +537,7 @@ editPage' params = do
                    , br
                    , label ! [thefor "logMsg"] << "Description of changes:"
                    , br
-                   , textfield "logMsg" ! (readonly ++ [value logMsg])
+                   , textfield "logMsg" ! (readonly ++ [value (logMsg `orIfNull` defaultSummary cfg) ])
                    , submit "update" "Save"
                    , primHtmlChar "nbsp"
                    , submit "cancel" "Discard"


### PR DESCRIPTION
* The "view revision" page now contains a hint about viewing the latest version of the page without URL editing (it is notevident that the page title is a link)
* If the default summary for edits is specified, fill the box with it. This may encourage users to fill this field (e.g. by specifying something like "I am too lazy to fill the description" as the default message).