### PR TITLE
Master jgm downgrade hoauth2

### DIFF
--- a/gitit.cabal
+++ b/gitit.cabal
@@ -170,7 +170,7 @@ Library
                      aeson >= 0.7 && < 1.5,
                      uuid >= 1.3 && < 1.4,
                      network-uri >= 2.6,
-                     network >= 2.6,
+                     network >= 2.6 && < 2.7,
                      doctemplates >= 0.7.1
   if flag(plugins)
     exposed-modules: Network.Gitit.Interface

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -134,7 +134,7 @@ Library
                      directory,
                      mtl,
                      old-time,
-                     pandoc >= 2.8 && < 2.10,
+                     pandoc >= 2.8 && < 2.9,
                      pandoc-types >= 1.20 && < 1.21,
                      skylighting >= 0.8.2.3 && < 0.9,
                      bytestring,

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -163,7 +163,7 @@ Library
                      json >= 0.4 && < 0.10,
                      uri-bytestring >= 0.2.3.3,
                      split,
-                     hoauth2 >= 1.3.0 && < 1.10,
+                     hoauth2 >= 1.3.0 && < 1.9,
                      xml-conduit >= 1.5 && < 1.10,
                      http-conduit >= 2.1.6 && < 2.4,
                      http-client-tls >= 0.2.2 && < 0.4,


### PR DESCRIPTION
This pull request downgrades some build dependencies in gitit.cabal by setting an upper bound for the following dependencies.
```
 pandoc >= 2.8 && < 2.9,
 hoauth2 >= 1.3.0 && < 1.9,
 network >= 2.6 && < 2.7,
```
The build with `cabal install` otherwise takes a higher version which would require some code modifications (e.g. some functions types in these dependencies change at the upper bound version).
The build with stack has not this problem because the dependencies in stackage for the resolver used in stack.yaml (lts14.14) are already within these bounds.
