### PR TITLE
Add 'public instances running badge' to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-Gitit
+Gitit [![Publicly running instances](https://img.shields.io/badge/Public%20instances%20running-10.7k-brightgreen)](https://www.google.com/search?q=%22powered+by+gitit%22)
 =====
 
 Gitit is a wiki program written in Haskell. It uses [Happstack] for


### PR DESCRIPTION
Badge shall be updated manually.
If you want to implement a thing, what relays the image and edits the url by implementing a solution to get how many results google says it gets you with the api with cron, go for it. ;)
Closes #639 