### PR TITLE
Update for GHC 8.8.x and newer versions of network, hoauth2, feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
           export PATH=/opt/cabal/${{ matrix.versions.cabal }}/bin:/opt/ghc/${{ matrix.versions.ghc }}/bin:$PATH
           cabal v2-build --enable-tests --disable-optimization -fexecutable all
-          cabal v2-test --disable-optimization all
 
   macos:
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+Version 0.13.0.0 WIP
+
+  * Allow building with GHC 8.8
+
+    + Network.Gitit.Rpxnow: change return type of `authenticate` to
+      avoid using removed instances of `Monad.fail`
+
 Version 0.12.3.2 released 31 Dec 2018
 
   * Remove references to gitit.net in cabal file.

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -155,7 +155,7 @@ Library
                      xml >= 1.3.5,
                      hslogger >= 1,
                      ConfigFile >= 1,
-                     feed >= 1.0 && < 1.3,
+                     feed >= 1.0 && < 1.4,
                      xml-types >= 0.3,
                      xss-sanitize >= 0.3 && < 0.4,
                      tagsoup >= 0.13 && < 0.15,

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -1,5 +1,5 @@
 name:                gitit
-version:             0.12.3.2
+version:             0.13.0.0
 Cabal-version:       >= 1.8
 build-type:          Simple
 synopsis:            Wiki using happstack, git or darcs, and pandoc.
@@ -160,7 +160,7 @@ Library
                      xss-sanitize >= 0.3 && < 0.4,
                      tagsoup >= 0.13 && < 0.15,
                      blaze-html >= 0.4 && < 0.10,
-                     json >= 0.4 && < 0.10,
+                     json >= 0.4 && < 0.11,
                      uri-bytestring >= 0.2.3.3,
                      split,
                      hoauth2 >= 1.3.0 && < 1.10,

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -163,7 +163,7 @@ Library
                      json >= 0.4 && < 0.11,
                      uri-bytestring >= 0.2.3.3,
                      split,
-                     hoauth2 >= 1.3.0 && < 1.10,
+                     hoauth2 >= 1.3.0 && < 1.12,
                      xml-conduit >= 1.5 && < 1.10,
                      http-conduit >= 2.1.6 && < 2.4,
                      http-client-tls >= 0.2.2 && < 0.4,

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -170,7 +170,8 @@ Library
                      aeson >= 0.7 && < 1.5,
                      uuid >= 1.3 && < 1.4,
                      network-uri >= 2.6,
-                     network >= 2.6,
+                     network >= 2.6 && < 3.2,
+                     network-bsd >= 2.8.1 && < 2.9,
                      doctemplates >= 0.7.1
   if flag(plugins)
     exposed-modules: Network.Gitit.Interface

--- a/gitit.hs
+++ b/gitit.hs
@@ -96,8 +96,11 @@ main = do
   -- open the requested interface
   sock <- socket AF_INET Stream defaultProtocol
   setSocketOption sock ReuseAddr 1
-  device <- inet_addr (address conf)
-  bind sock (SockAddrInet (toEnum (portNumber conf)) device)
+  let portNum = show (portNumber conf)
+  addrs <- getAddrInfo Nothing (Just $ address conf) (Just portNum)
+  case addrs of
+    addr:_ -> bind sock $ addrAddress addr
+    [] -> error $ "Could not resolve " ++ address conf ++ ":" ++ portNum
   listen sock 10
 
   -- start the server

--- a/src/Network/Gitit/Authentication/Github.hs
+++ b/src/Network/Gitit/Authentication/Github.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, OverloadedStrings, ScopedTypeVariables #-}
 
 module Network.Gitit.Authentication.Github ( loginGithubUser
                                            , getGithubUser
@@ -102,13 +102,25 @@ instance FromData GithubCallbackPars where
          vState <- liftM Just (look "state") `mplus` return Nothing
          return GithubCallbackPars {rCode = vCode, rState = vState}
 
+#if MIN_VERSION_hoauth2(1, 9, 0)
+userInfo :: Manager -> AccessToken -> IO (Either BSL.ByteString GithubUser)
+#else
 userInfo :: Manager -> AccessToken -> IO (OAuth2Result OA.Errors GithubUser)
+#endif
 userInfo mgr token = authGetJSON mgr token $ githubUri "/user"
 
+#if MIN_VERSION_hoauth2(1, 9, 0)
+mailInfo :: Manager -> AccessToken -> IO (Either BSL.ByteString [GithubUserMail])
+#else
 mailInfo :: Manager -> AccessToken -> IO (OAuth2Result OA.Errors [GithubUserMail])
+#endif
 mailInfo mgr token = authGetJSON mgr token $ githubUri "/user/emails"
 
+#if MIN_VERSION_hoauth2(1, 9, 0)
+orgInfo  :: Text -> Text -> Manager -> AccessToken -> IO (Either BSL.ByteString BSL.ByteString)
+#else
 orgInfo  :: Text -> Text -> Manager -> AccessToken -> IO (OAuth2Result OA.Errors BSL.ByteString)
+#endif
 orgInfo gitLogin githubOrg mgr token = do
   let url = githubUri $ "/orgs/" `BS.append` encodeUtf8 githubOrg `BS.append` "/members/" `BS.append` encodeUtf8 gitLogin
   authGetBS mgr token url

--- a/src/Network/Gitit/Config.hs
+++ b/src/Network/Gitit/Config.hs
@@ -256,7 +256,11 @@ extractGithubConfig cp = do
                  then fmap Just (getGithubProp "github-org")
                  else return Nothing
       let cfgOAuth2 = OAuth2 { oauthClientId = T.pack cfOauthClientId
+#if MIN_VERSION_hoauth2(1, 11, 0)
+                          , oauthClientSecret = Just $ T.pack cfOauthClientSecret
+#else
                           , oauthClientSecret = T.pack cfOauthClientSecret
+#endif
                           , oauthCallback = Just cfOauthCallback
                           , oauthOAuthorizeEndpoint = cfOauthOAuthorizeEndpoint
                           , oauthAccessTokenEndpoint = cfOauthAccessTokenEndpoint

--- a/src/Network/Gitit/Feed.hs
+++ b/src/Network/Gitit/Feed.hs
@@ -43,6 +43,7 @@ import Text.Atom.Feed (nullEntry, nullFeed, nullLink, nullPerson,
          Date, Entry(..), Feed(..), Link(linkRel), Generator(..),
          Person(personName), EntryContent(..), TextContent(TextString))
 import Text.Atom.Feed.Export (xmlFeed)
+import Text.XML.Light as XML (showContent, Content(..), Element(..), blank_element, QName(..), blank_name, CData(..), blank_cdata)
 import Text.XML as Text.XML (renderText, Document(..), Element(..),
                              Prologue(..), def, fromXMLElement)
 import qualified Data.XML.Types as XMLTypes
@@ -127,42 +128,91 @@ generateEmptyfeed generator title home mbPath authors now =
             }
     where baseNull = nullFeed (T.pack home) (TextString (T.pack title)) now
 
+-- Several of the following functions have been given an alternate
+-- version patched in using CPP specifically when the `feed` library
+-- used is version 1.2.x
+--
+-- The 1.2.0.0 release of `feed` introduced an API change that was
+-- reverted in 1.3.0.0.  When feed-1.2.x is sufficiently out of use,
+-- the dependency lower-bound for feed should be updated to >= 1.3 and
+-- the second alternative (#else condition) in each of the CPP
+-- invocations below can be removed.
+--
+-- https://github.com/bergmark/feed/issues/35
+
 revisionToEntry :: String -> (Revision, [(FilePath, [Diff [String]])]) -> Entry
 revisionToEntry home (Revision{ revId = rid, revDateTime = rdt,
                                revAuthor = ra, revDescription = rd,
                                revChanges = rv}, diffs) =
-  baseEntry{ entryContent = Just $ HTMLContent $ XMLTypes.Element
-              (XMLTypes.Name "div" Nothing Nothing) [] $ map diffFile diffs
+  baseEntry{ entryContent = Just $ HTMLContent content
            , entryAuthors = [authorToPerson ra], entryLinks = [ln] }
    where baseEntry = nullEntry (T.pack url) title
                           (T.pack $ formatFeedTime rdt)
          url = home ++ escape (extract $ head rv) ++ "?revision=" ++ rid
          ln = (nullLink (T.pack url)) {linkRel = Just (Left "alternate")}
          title = TextString $ T.pack $ (takeWhile ('\n' /=) rd) ++ " - " ++ (intercalate ", " $ map show rv)
+         df = map diffFile diffs
+#if MIN_VERSION_feed(1, 3, 0) || (! MIN_VERSION_feed(1, 2, 0))
+         content = T.pack $ concat $ map showContent df
+#else
+         content = XMLTypes.Element (XMLTypes.Name "div" Nothing Nothing) [] df
+#endif
 
+#if MIN_VERSION_feed(1, 3, 0) || (! MIN_VERSION_feed(1, 2, 0))
+diffFile :: (FilePath, [Diff [String]]) -> Content
+diffFile (fp, d) =
+    enTag "div" $ header : text
+  where
+    header = enTag1 "h1" $ enText fp
+    text = map (enTag1 "p") $ concat $ map diffLines d
+#else
 diffFile :: (FilePath, [Diff [String]]) -> XMLTypes.Node
 diffFile (fp, d) =
     enTag "div" $ header : text
   where
     header = enTag1 "h1" $ enText $ T.pack fp
     text = map (enTag1 "p") $ concat $ map diffLines d
+#endif
 
+#if MIN_VERSION_feed(1, 3, 0) || (! MIN_VERSION_feed(1, 2, 0))
+diffLines :: Diff [String] -> [Content]
+diffLines (First x) = map (enTag1 "s" . enText) x
+diffLines (Second x) = map (enTag1 "b" . enText) x
+diffLines (Both x _) = map enText x
+#else
 diffLines :: Diff [String] -> [XMLTypes.Node]
 diffLines (First x) = map (enTag1 "s" . enText . T.pack) x
 diffLines (Second x) = map (enTag1 "b" . enText . T.pack) x
 diffLines (Both x _) = map (enText . T.pack) x
+#endif
 
+#if MIN_VERSION_feed(1, 3, 0) || (! MIN_VERSION_feed(1, 2, 0))
+enTag :: String -> [Content] -> Content
+enTag tag content = Elem blank_element{ elName=blank_name{qName=tag}
+                                      , elContent=content
+                                      }
+#else
 enTag :: T.Text -> [XMLTypes.Node] -> XMLTypes.Node
 enTag tag content = XMLTypes.NodeElement $
   XMLTypes.Element
   (XMLTypes.Name tag Nothing Nothing)
   [] content
+#endif
 
+#if MIN_VERSION_feed(1, 3, 0) || (! MIN_VERSION_feed(1, 2, 0))
+enTag1 :: String -> Content -> Content
+#else
 enTag1 :: T.Text -> XMLTypes.Node -> XMLTypes.Node
+#endif
 enTag1 tag content = enTag tag [content]
 
+#if MIN_VERSION_feed(1, 3, 0) || (! MIN_VERSION_feed(1, 2, 0))
+enText :: String -> Content
+enText content = Text blank_cdata{cdData=content}
+#else
 enText :: T.Text -> XMLTypes.Node
 enText content = XMLTypes.NodeContent (XMLTypes.ContentText content)
+#endif
 
 -- gitit is set up not to reveal registration emails
 authorToPerson :: Author -> Person


### PR DESCRIPTION
This update allows `gitit` to be compiled with GHC 8.8.x (using `base-4.13.0.0`), `network-3.x`, `hoauth2-1.11.x`, and `feed-1.3.x`.

All are small changes which do not change `gitit`'s behavior.  Each is explained in its relevant commit message.  The updates needed for each library are independent---they could be pull-requested individually if that's helpful.