### PR TITLE
git-ignore "/.stack-work/" and "/static/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ my.conf
 gitit-users
 .cabal-sandbox
 github.conf
+/.stack-work/
+/static/


### PR DESCRIPTION
I guess the build-system created these ... (am a Haskell newb)