### PR TITLE
.cabal: allow building with hoauth-1.14

### DIFF
--- a/gitit.cabal
+++ b/gitit.cabal
@@ -164,7 +164,7 @@ Library
                      json >= 0.4 && < 0.11,
                      uri-bytestring >= 0.2.3.3,
                      split,
-                     hoauth2 >= 1.3.0 && < 1.12,
+                     hoauth2 >= 1.3.0 && < 1.15,
                      xml-conduit >= 1.5 && < 1.10,
                      http-conduit >= 2.1.6 && < 2.4,
                      http-client-tls >= 0.2.2 && < 0.4,


### PR DESCRIPTION
I can build gitit-0.13.0.0 with hoauth2-1.14.0 (LTS16)

So maybe with this change gitit could even be added to Stackage LTS 16.