### PR TITLE
Created a workflow for building binaries on release

### DIFF
--- a/.github/workflows/create-assets.yml
+++ b/.github/workflows/create-assets.yml
@@ -1,0 +1,81 @@
+name: Create Assets
+
+on:
+  release:
+    types: [published]
+
+env:
+  PROGRAM: gitit
+  DIR: gitit
+  EXTRA_ASSETS: data LICENSE YUI-LICENSE README.markdown
+  PROXY: unix-proxy.sh
+  HIDDEN_BIN: gitit-bin
+
+jobs:
+  create-assets:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build the project
+      run: stack build --ghc-options=-rtsopts
+
+      # This also renames the program name and instead injects a proxy shell
+      # script that takes care of overriding the cabal inserted paths before
+      # running the actual program
+
+    - name: Save the binary with plugins
+      run: mv `stack exec -- which $PROGRAM` the-binary
+
+    - name: Build the project without plugins
+      run: stack build --ghc-options=-rtsopts --flag gitit:-plugins
+
+    - name: Save the binary without plugins
+      run: mv `stack exec -- which $PROGRAM` the-binary-noplugins
+
+    - name: Prepare directory (no plugins)
+      run: |
+        mkdir $DIR
+        mv the-binary-noplugins $DIR/$HIDDEN_BIN
+        DIR=$DIR stack runhaskell -- CopyAssets.hs filestore
+        mv $PROXY $DIR/$PROGRAM
+        mv $EXTRA_ASSETS $DIR
+
+    - name: Tar the directory (no plugins)
+      run: |
+        tar -cavf $DIR-noplugins.tar.gz $DIR
+
+
+    - name: Prepare directory (with plugins)
+      run: |
+        mv the-binary $DIR/$HIDDEN_BIN
+        mv plugins $DIR
+
+
+    - name: Tar the directory (with plugins)
+      run: |
+        tar -cavf $DIR.tar.gz $DIR
+
+    - name: Upload artifact with plugins
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ env.DIR }}.tar.gz
+        asset_name: gitit-${{ runner.os }}.tar.gz
+        asset_content_type: application/tar.gz
+
+    - name: Upload artifact without plugins
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ env.DIR }}-noplugins.tar.gz
+        asset_name: gitit-${{ runner.os }}-noplugins.tar.gz
+        asset_content_type: application/tar.gz

--- a/CopyAssets.hs
+++ b/CopyAssets.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE LambdaCase #-}
+import System.Directory
+import System.FilePath
+import System.Process
+import Data.List
+import System.Environment
+import GHC.Stack
+import Control.Monad
+import System.IO.Unsafe
+
+mustBeOne :: (HasCallStack, Show a) => [a] -> a
+mustBeOne = \case 
+    [one] -> one
+    [] -> error "Expected one element, got 0"
+    other -> error $ "Expected one element, got " ++ show (length other) ++ ": " ++ show other
+
+main = do
+    packages <- getArgs
+    dir <- getEnv "DIR"
+    forM_ packages $ \package -> do
+        dataDir <- drop (length "data-dir: ") . head . lines <$> readProcess "stack" ["exec", "--", "ghc-pkg", "field", package, "data-dir"] ""
+        let targetDir = dir </> "vendor-data"
+        createDirectoryIfMissing True targetDir
+        callProcess "cp" ["-R", dataDir, targetDir </> package]

--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,29 @@ Other features include
 Getting started
 ===============
 
+Using a prebuilt binary
+-----------------------------
+
+We use GitHub Actions to build pre-packaged binaries + assets of gitit. They are
+built on the latest MacOS and Ubuntu available on GitHub. This installation
+method is the easiest one, however it may not work on your machine if you have a
+different OS or OS version.
+
+We recommend trying a prebuilt package first, and should you encounter issues,
+try compiling it yourself.
+
+On Debain and Ubuntu you'll need to first install the `libtinfo5` package with
+`sudo apt install libtinfo5`.
+
+You can download the package for your platform [on the releases
+page](/releases). Simply unpack the archive (`tar -xf gitit-<platform>.tar.gz`)
+and run the `gitit` executable inside.
+
+*Note*: gitit will automatically create and use a `wikidata` folder in whatever
+directory is run. To configure this you can run the `gitit` executable from
+anywhere, but you **may not** move the executable from the folder unpacked from
+the archive.
+
 Compiling and installing gitit
 ------------------------------
 

--- a/unix-proxy.sh
+++ b/unix-proxy.sh
@@ -1,0 +1,14 @@
+#!bash
+# This script proxies the `gitit` top-level executable when using a prebuilt
+# version of gitit. Really the only job of this script is to set the environment
+# variables overriding the paths set by cabal. For more information on why this
+# works see
+# https://www.haskell.org/cabal/users-guide/developing-packages.html#accessing-data-files-from-package-code
+
+# From https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+export gitit_datadir=$SCRIPTPATH
+export filestore_datadir=$SCRIPTPATH/vendor-data/filestore
+
+exec $SCRIPTPATH/gitit-bin "$@"


### PR DESCRIPTION
This PR adds a new workflow, which build the project and then packages the compiled binaries and other asset files into standalone archives that users can download and use immediately without the need to install the many libraries gitit depends on and works without having GHC installed.

The workflow only executes when a release is triggered and it creates and uploads tarballs for Linux (latest Ubuntu version available on github actions) and macOS and both with and without plugins respectively. For an example you can visit the releases section of my fork.

This of course does not cater to all users of gitit, but I think it will make it significantly easier for new users to try the software. In particular because gitit depends on pandoc, the build times for a first time build are insane. I think it took over 30 minutes on my modern machine

I've described the way this PR was created in more detail including my handling of `data-dir` style assets in [this blogpost](https://justus.science/blog/2020/08/27/creating-executables-with-actions.html).