### PR TITLE
Add option for disabling registration

### DIFF
--- a/data/default.conf
+++ b/data/default.conf
@@ -191,6 +191,9 @@ recaptcha-public-key:
 # specifies the public and private keys for the reCAPTCHA service.
 # To get these, you need to create an account at http://recaptcha.net.
 
+disable-registration: no
+# if "yes", disables registering new users on the wiki
+
 access-question:
 access-question-answers:
 # specifies a question that users must answer when they attempt to create

--- a/src/Network/Gitit/Authentication.hs
+++ b/src/Network/Gitit/Authentication.hs
@@ -350,10 +350,12 @@ loginForm dest = do
       , textfield "destination" ! [thestyle "display: none;", value dest]
       , submit "login" "Login" ! [intAttr "tabindex" 3]
       ] +++
-    p << [ stringToHtml "If you do not have an account, "
-         , anchor ! [href $ base' ++ "/_register?" ++
-           urlEncodeVars [("destination", encodeString dest)]] << "click here to get one."
-         ] +++
+    if not (disableRegistration cfg)
+       then noHtml
+       else p << [ stringToHtml "If you do not have an account, "
+                 , anchor ! [href $ base' ++ "/_register?" ++
+                     urlEncodeVars [("destination", encodeString dest)]] << "click here to get one."
+                 ] +++
     if null (mailCommand cfg)
        then noHtml
        else p << [ stringToHtml "If you forgot your password, "
@@ -410,11 +412,18 @@ registerUserForm = registerForm >>=
                     pgTitle = "Register for an account"
                     }
 
-formAuthHandlers :: [Handler]
-formAuthHandlers =
+regAuthHandlers :: [Handler]
+regAuthHandlers =
   [ dir "_register"  $ method GET >> registerUserForm
   , dir "_register"  $ method POST >> withData registerUser
-  , dir "_login"     $ method GET  >> loginUserForm
+  ]
+
+formAuthHandlers :: Bool -> [Handler]
+formAuthHandlers disableReg =
+  (if disableReg
+    then []
+    else regAuthHandlers) ++
+  [ dir "_login"     $ method GET  >> loginUserForm
   , dir "_login"     $ method POST >> withData loginUser
   , dir "_logout"    $ method GET  >> withData logoutUser
   , dir "_resetPassword"   $ method GET  >> withData resetPasswordRequestForm

--- a/src/Network/Gitit/Config.hs
+++ b/src/Network/Gitit/Config.hs
@@ -110,6 +110,7 @@ extractConfig cp = do
       cfNoDelete <- get cp "DEFAULT" "no-delete"
       cfDefaultSummary <- get cp "DEFAULT" "default-summary"
       cfDeleteSummary <- get cp "DEFAULT" "delete-summary"
+      cfDisableRegistration <- get cp "DEFAULT" "disable-registration"
       cfAccessQuestion <- get cp "DEFAULT" "access-question"
       cfAccessQuestionAnswers <- get cp "DEFAULT" "access-question-answers"
       cfUseRecaptcha <- get cp "DEFAULT" "use-recaptcha"
@@ -181,7 +182,7 @@ extractConfig cp = do
                                        _         -> ForModify
 
         , authHandler          = case authMethod of
-                                      "form"     -> msum formAuthHandlers
+                                      "form"     -> msum $ formAuthHandlers cfDisableRegistration
                                       "github"   -> msum $ githubAuthHandlers ghConfig
                                       "http"     -> msum httpAuthHandlers
                                       "rpx"      -> msum rpxAuthHandlers
@@ -209,6 +210,7 @@ extractConfig cp = do
         , noDelete             = splitCommaList cfNoDelete
         , defaultSummary       = cfDefaultSummary
         , deleteSummary        = cfDeleteSummary
+        , disableRegistration  = cfDisableRegistration
         , accessQuestion       = if null cfAccessQuestion
                                     then Nothing
                                     else Just (cfAccessQuestion, splitCommaList cfAccessQuestionAnswers)

--- a/src/Network/Gitit/Types.hs
+++ b/src/Network/Gitit/Types.hs
@@ -169,6 +169,8 @@ data Config = Config {
   -- be given the prompt and must give
   -- one of the answers to register.
   accessQuestion       :: Maybe (String, [String]),
+  -- | Disable Registration?
+  disableRegistration  :: Bool,
   -- | Use ReCAPTCHA for user registration.
   useRecaptcha         :: Bool,
   recaptchaPublicKey   :: String,


### PR DESCRIPTION
This adds an option to disable user registration. While I can hack it now with an access question, this feels like a more secure way to do this as it leaves one less endpoint that hackers could potentially exploit.