### PR TITLE
Allow compilation with pandoc 2.12 and 2.13

### DIFF
--- a/gitit.cabal
+++ b/gitit.cabal
@@ -135,7 +135,7 @@ Library
                      directory,
                      mtl,
                      old-time,
-                     pandoc >= 2.9 && < 2.12,
+                     pandoc >= 2.9 && < 2.14,
                      pandoc-types >= 1.20 && < 1.23,
                      skylighting >= 0.8.2.3 && < 0.11,
                      bytestring,

--- a/src/Network/Gitit/Authentication.hs
+++ b/src/Network/Gitit/Authentication.hs
@@ -44,7 +44,7 @@ import System.Exit
 import System.Log.Logger (logM, Priority(..))
 import Data.Char (isAlphaNum, isAlpha)
 import qualified Data.Map as M
-import Text.Pandoc.Shared (substitute)
+import Data.List (stripPrefix)
 import Data.Maybe (isJust, fromJust, isNothing, fromMaybe)
 import Network.URL (exportURL, add_param, importURL)
 import Network.BSD (getHostName)
@@ -53,6 +53,16 @@ import Network.HTTP (urlEncodeVars, urlDecode, urlEncode)
 import Codec.Binary.UTF8.String (encodeString)
 import Data.ByteString.UTF8 (toString)
 import Network.Gitit.Rpxnow as R
+
+-- | Replace each occurrence of one sublist in a list with another.
+--   Vendored in from pandoc 2.11.4 as 2.12 removed this function.
+substitute :: (Eq a) => [a] -> [a] -> [a] -> [a]
+substitute _ _ [] = []
+substitute [] _ xs = xs
+substitute target replacement lst@(x:xs) =
+    case stripPrefix target lst of
+      Just lst' -> replacement ++ substitute target replacement lst'
+      Nothing   -> x : substitute target replacement xs
 
 data ValidationType = Register
                     | ResetPassword

--- a/src/Network/Gitit/Util.hs
+++ b/src/Network/Gitit/Util.hs
@@ -45,7 +45,11 @@ import Network.URL (encString)
 
 -- | Read file as UTF-8 string.  Encode filename as UTF-8.
 readFileUTF8 :: FilePath -> IO Text
+#if MIN_VERSION_pandoc(2,12,0)
+readFileUTF8 = UTF8.readFile
+#else
 readFileUTF8 = fmap T.pack . UTF8.readFile
+#endif
 
 -- | Perform a function a directory and return to working directory.
 inDir :: FilePath -> IO a -> IO a


### PR DESCRIPTION
pandoc 2.13 introduced the following breakages for gitit:

* UTF8.readFile now returns a Text which is actually ideal for gitit.
  If pandoc is new enough we just make readFileUTF8 an alias for
  UTF8.readFile.

* Text.Pandoc.Shared no longer exports substitute. In order to be
  conservative I've chosen to just copy the substitute function from
  pandoc 2.11.4. I need this patch kind of urgently so I didn't want to
  make any changes or refactors independently from upstream if
  avoidable. However, I'd be happy to rebase this PR branch to adopt a
  different solution to just copying the function.