### PR TITLE
Give the .underline class an underline

### DIFF
--- a/data/static/css/screen.css
+++ b/data/static/css/screen.css
@@ -191,3 +191,4 @@ sup + sup { margin-left: 2px; }
   }
 }
 
+.underline { text-decoration: underline; }


### PR DESCRIPTION
As it stands, at least sometimes, converting org-mode `_underlined text_` to HTML produces the code `<span class="underline">underlined text</span>`. This is not actually styled as underlined, due to a lack of an appropriate rule in the CSS. Thus, adding a rule to style elements with the `underline` class with an underline seems like an appropriate remedy, unless it'd be better to render the text as `<u>underlined text</u>`.