### PR TITLE
Support pandoc 2.17 and adjust for hoauth2 >= 2.3.0

### DIFF
--- a/gitit.cabal
+++ b/gitit.cabal
@@ -162,7 +162,7 @@ Library
                      json >= 0.4 && < 0.11,
                      uri-bytestring >= 0.2.3.3,
                      split,
-                     hoauth2 >= 1.3.0 && < 1.17,
+                     hoauth2 >= 2.3.0 && < 2.4,
                      xml-conduit >= 1.5 && < 1.10,
                      http-conduit >= 2.1.6 && < 2.4,
                      http-client-tls >= 0.2.2 && < 0.4,

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -133,7 +133,7 @@ Library
                      mtl,
                      old-time,
                      temporary,
-                     pandoc >= 2.9 && < 2.17,
+                     pandoc >= 2.9 && < 2.18,
                      pandoc-types >= 1.20 && < 1.23,
                      skylighting >= 0.8.2.3 && < 0.13,
                      bytestring,

--- a/src/Network/Gitit/Config.hs
+++ b/src/Network/Gitit/Config.hs
@@ -40,7 +40,7 @@ import Paths_gitit (getDataFileName)
 import System.FilePath ((</>))
 import Text.Pandoc hiding (ERROR, WARNING, MathJax, MathML, WebTeX, getDataFileName)
 import qualified Control.Exception as E
-import Network.OAuth.OAuth2 (OAuth2(..), oauthCallback, oauthOAuthorizeEndpoint, oauthClientId, oauthClientSecret)
+import Network.OAuth.OAuth2 (OAuth2(..))
 import URI.ByteString (parseURI, laxURIParserOptions)
 import qualified Data.ByteString.Char8 as BS
 import Network.Gitit.Compat.Except
@@ -254,15 +254,11 @@ extractGithubConfig cp = do
       cfOrg <- if hasGithubProp "github-org"
                  then fmap Just (getGithubProp "github-org")
                  else return Nothing
-      let cfgOAuth2 = OAuth2 { oauthClientId = T.pack cfOauthClientId
-#if MIN_VERSION_hoauth2(1, 11, 0)
-                          , oauthClientSecret = Just $ T.pack cfOauthClientSecret
-#else
-                          , oauthClientSecret = T.pack cfOauthClientSecret
-#endif
-                          , oauthCallback = Just cfOauthCallback
-                          , oauthOAuthorizeEndpoint = cfOauthOAuthorizeEndpoint
-                          , oauthAccessTokenEndpoint = cfOauthAccessTokenEndpoint
+      let cfgOAuth2 = OAuth2 { oauth2ClientId = T.pack cfOauthClientId
+                          , oauth2ClientSecret = T.pack cfOauthClientSecret
+                          , oauth2RedirectUri = cfOauthCallback
+                          , oauth2AuthorizeEndpoint = cfOauthOAuthorizeEndpoint
+                          , oauth2TokenEndpoint = cfOauthAccessTokenEndpoint
                           }
       return $ githubConfig cfgOAuth2 $ fmap T.pack cfOrg
   where getGithubProp = get cp "Github"

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,38 +15,9 @@ flags:
 packages:
 - '.'
 extra-deps:
-- skylighting-core-0.12.1
-- skylighting-0.12.1
-- doctemplates-0.10
-- ConfigFile-1.1.4
 - filestore-0.6.5
 - recaptcha-0.1.0.4
-- MissingH-1.4.3.0
-- json-0.10
-- pandoc-2.16.2
-- HStringTemplate-0.8.8
-- lpeg-1.0.1
-- hslua-2.0.1
-- hslua-classes-2.0.0
-- hslua-core-2.0.0.2
-- hslua-marshalling-2.0.1
-- hslua-module-path-1.0.0
-- hslua-module-system-1.0.0
-- hslua-module-text-1.0.0
-- hslua-module-version-1.0.0
-- hslua-objectorientation-2.0.1
-- hslua-packaging-2.0.0
-- lua-2.0.1
-- tasty-hslua-1.0.0
-- tasty-lua-1.0.0
-- pandoc-types-1.22.1
-- commonmark-0.2.1.1
-- commonmark-extensions-0.2.2.1
-- citeproc-0.6
-- aeson-pretty-0.8.9
-- ipynb-0.1.0.2
-- texmath-0.12.3.3
 
-resolver: lts-18.18
+resolver: nightly-2022-03-12
 nix:
   packages: [zlib]


### PR DESCRIPTION
These versions are used in Stackage Nightly and we probably want to support them in gitit

* Builds with pandoc 2.17 without any problems
* `hoauth2` needs some bigger adjustments. See the commit message for the reasoning for supporting such a small version range.