### PR TITLE
Support for accesskey shortcuts

### DIFF
--- a/data/Help.page
+++ b/data/Help.page
@@ -123,3 +123,27 @@ picture into a (markdown-formatted) page as follows: `![fido](fido.jpg)`.
 If you uploaded a PDF `projection.pdf`, you can insert a link to it
 using:  `[projection](projection.pdf)`.
 
+# Keyboard shortcuts
+
+Gitit supports keyboard shortcuts similar to
+[MediaWiki's](https://www.mediawiki.org/wiki/Manual:Access_keys).
+
+Key   Action
+----  -------
+f     Move cursor to search box
+r     Recent activity
+x     Random page
+z     Front page
+o     Log in
+e     Edit current page
+h     View history
+p     Printable version
+t     Switch to discussion page
+c     Switch to content page
+,     Move cursor to edit box
+b     Move cursor to description of changes
+p     Preview
+s     Save
+d     Delete current page
+
+Table: Access keys

--- a/data/templates/pagetools.st
+++ b/data/templates/pagetools.st
@@ -3,8 +3,8 @@
     <legend>This page</legend>
     <ul>
       <li><a href="$base$/_showraw$pageUrl$$if(revision)$?revision=$revision$$endif$">Raw page source</a></li>
-      <li><a href="$base$$pageUrl$?printable$if(revision)$&amp;revision=$revision$$endif$">Printable version</a></li>
-      <li><a href="$base$/_delete$pageUrl$">Delete this page</a></li>
+      <li><a href="$base$$pageUrl$?printable$if(revision)$&amp;revision=$revision$$endif$" accesskey="p">Printable version</a></li>
+      <li><a href="$base$/_delete$pageUrl$" accesskey="d">Delete this page</a></li>
       $if(feed)$
       <li><a href="$base$/_feed$pageUrl$" type="application/atom+xml" rel="alternate" title="This page's ATOM Feed">Atom feed</a> <img alt="feed icon" src="$base$/img/icons/feed.png"/></li>
       $endif$

--- a/data/templates/sitenav.st
+++ b/data/templates/sitenav.st
@@ -2,11 +2,11 @@
   <fieldset>
     <legend>Site</legend>
     <ul>
-      <li><a href="$base$/">Front page</a></li>
+      <li><a href="$base$/" accesskey="z">Front page</a></li>
       <li><a href="$base$/_index">All pages</a></li>
       <li><a href="$base$/_categories">Categories</a></li>
-      <li><a href="$base$/_random">Random page</a></li>
-      <li><a href="$base$/_activity">Recent activity</a></li>
+      <li><a href="$base$/_random" accesskey="x">Random page</a></li>
+      <li><a href="$base$/_activity" accesskey="r">Recent activity</a></li>
       $if(wikiupload)$
         <li><a href="$base$/_upload">Upload a file</a></li>
       $endif$
@@ -16,7 +16,7 @@
       <li><a href="$base$/Help">Help</a></li>
     </ul>
     <form action="$base$/_search" method="get" id="searchform">
-     <input type="text" name="patterns" id="patterns"/>
+     <input type="text" name="patterns" id="patterns" accesskey="f"/>
      <input type="submit" name="search" id="search" value="Search"/>
     </form>
     <form action="$base$/_go" method="post" id="goform">

--- a/data/templates/userbox.st
+++ b/data/templates/userbox.st
@@ -4,6 +4,6 @@
     <a href="$base$/_logout">Logout</a>
   </noscript>
   &nbsp;
-  <a id="loginlink" class="login" href="$base$/_login">Login / Get an account</a>
+  <a id="loginlink" class="login" href="$base$/_login" accesskey="o">Login / Get an account</a>
   <a id="logoutlink" class="login" href="$base$/_logout">Logout <span id="logged_in_user"></span></a>
 </div>

--- a/src/Network/Gitit/Handlers.hs
+++ b/src/Network/Gitit/Handlers.hs
@@ -491,6 +491,9 @@ getDiff fs file from to = do
               " to " ++ fromMaybe "current" to) +++
            pre ! [theclass "diff"] << map diffLineToHtml rawDiff
 
+accesskey :: Char -> HtmlAttr
+accesskey c = strAttr "accesskey" [c]
+
 editPage :: Handler
 editPage = withData editPage'
 
@@ -532,12 +535,12 @@ editPage' params = do
   let editForm = gui (base' ++ urlForPage page) ! [identifier "editform"] <<
                    [ sha1Box
                    , textarea ! (readonly ++ [cols "80", name "editedText",
-                                  identifier "editedText"]) << raw
+                                  identifier "editedText", accesskey ',']) << raw
                    , br
                    , label ! [thefor "logMsg"] << "Description of changes:"
                    , br
-                   , textfield "logMsg" ! (readonly ++ [value (logMsg `orIfNull` defaultSummary cfg) ])
-                   , submit "update" "Save"
+                   , textfield "logMsg" ! (readonly ++ [value (logMsg `orIfNull` defaultSummary cfg), accesskey 'b' ])
+                   , submit "update" "Save" ! [ accesskey 's' ]
                    , primHtmlChar "nbsp"
                    , submit "cancel" "Discard"
                    , primHtmlChar "nbsp"
@@ -545,6 +548,7 @@ editPage' params = do
                               identifier "previewButton",
                               strAttr "onClick" "updatePreviewPane();",
                               strAttr "style" "display: none;",
+                              accesskey 'p',
                               value "Preview" ]
                    , thediv ! [ identifier "previewpane" ] << noHtml
                    ]

--- a/src/Network/Gitit/Layout.hs
+++ b/src/Network/Gitit/Layout.hs
@@ -121,9 +121,12 @@ filledPageTemplate base' cfg layout htmlContents templ =
 
 -- auxiliary functions:
 
+accesskey :: Char -> HtmlAttr
+accesskey c = strAttr "accesskey" [c]
+
 linkForTab :: (Tab -> Html -> Html) -> String -> String -> Maybe String -> Tab -> Html
 linkForTab tabli base' page _ HistoryTab =
-  tabli HistoryTab << anchor ! [href $ base' ++ "/_history" ++ urlForPage page] << "history"
+  tabli HistoryTab << anchor ! [href $ base' ++ "/_history" ++ urlForPage page, accesskey 'h'] << "history"
 linkForTab tabli _ _ _ DiffTab =
   tabli DiffTab << anchor ! [href ""] << "diff"
 linkForTab tabli base' page rev ViewTab =
@@ -132,23 +135,24 @@ linkForTab tabli base' page rev ViewTab =
                       else s
   in if isDiscussPage page
         then tabli DiscussTab << anchor !
-              [href $ base' ++ urlForPage (origPage page)] << "page"
+              [href $ base' ++ urlForPage (origPage page), accesskey 'c'] << "page"
         else tabli ViewTab << anchor !
               [href $ base' ++ urlForPage page ++
                       case rev of
                            Just r  -> "?revision=" ++ r
-                           Nothing -> ""] << "view"
+                           Nothing -> "", accesskey 'c'] << "view"
 linkForTab tabli base' page _ DiscussTab =
   tabli (if isDiscussPage page then ViewTab else DiscussTab) <<
   anchor ! [href $ base' ++ if isDiscussPage page then "" else "/_discuss" ++
-                   urlForPage page] << "discuss"
+                   urlForPage page, accesskey 't'] << "discuss"
 linkForTab tabli base' page rev EditTab =
   tabli EditTab << anchor !
     [href $ base' ++ "/_edit" ++ urlForPage page ++
             case rev of
                   Just r   -> "?revision=" ++ r ++ "&" ++
                                urlEncodeVars [("logMsg", "Revert to " ++ r)]
-                  Nothing  -> ""] << if isNothing rev
+                  Nothing  -> "",
+        accesskey 'e'] << if isNothing rev
                                          then "edit"
                                          else "revert"
 


### PR DESCRIPTION
### Overview

Implementation of #609. See more details in the commit message of the first commit.

### Notes

I didn't know where to put function `accesskey`, so there are two copies: one in `Handlers.hs` and one in `Layout.hs`.  Perhaps it should go into `src/Network/Gitit/Util.hs`? It doesn't seem to have any code related to HTML generation at the moment.

I also don't know how exactly generation of default help page works, so I've just added new section "Keyboard shortcuts" to the bottom of `data/Help.page`. I wrote conservatively little about how keyboard shortcuts work, just referring the user to MediaWiki's manual, but I'm open to expanding the help text however you see fit.

### Testing

I've tested every accesskey locally by running Gitit from the repository:

```
$ stack build && stack exec gitit -- -f my.config
```