### PR TITLE
Feature/private pages (PR 579 rebased)

### DIFF
--- a/data/Help.page
+++ b/data/Help.page
@@ -93,7 +93,7 @@ highlighted in yellow, and deletions will be crossed out with a horizontal
 line.  Clicking on the description of changes will take you to the page
 as it existed after those changes.  To revert the page to the revision
 you're currently looking at, just click the "revert" button at the bottom
-of the page, then "Save". 
+of the page, then "Save".
 
 ## Deleting a page
 
@@ -122,4 +122,12 @@ For example, if you uploaded a picture `fido.jpg`, you can insert the
 picture into a (markdown-formatted) page as follows: `![fido](fido.jpg)`.
 If you uploaded a PDF `projection.pdf`, you can insert a link to it
 using:  `[projection](projection.pdf)`.
+
+# Private content
+
+By default, wiki content is accessible to all users, whether authenticated
+or not. However, it is possible to define pages or directories as private.
+In this case, you'll need to be authenticated to access them. Only the
+**content** of files will be inaccessible, the name of these files will
+remain visible in "All pages" or in "Recent activity".
 

--- a/data/default.conf
+++ b/data/default.conf
@@ -128,6 +128,14 @@ no-edit: Help
 # specifies pages that cannot be edited through the web interface.
 # Leave blank to allow every page to be edited.
 
+private-pages:
+# specifies pages that are considered private, i.e not accessible for
+# anonymous users. This setting overrides any other require-authentication
+# setting, visitors to private pages must be logged in.
+# Full paths and wildcards are both available, meaning that
+# /Dir/Page, /Dir/* and */Page will all blacklist
+# the /Dir/Page page.
+
 default-summary:
 # specifies text to be used in the change description if the author
 # leaves the "description" field blank.  If default-summary is blank

--- a/data/default.conf
+++ b/data/default.conf
@@ -129,12 +129,11 @@ no-edit: Help
 # Leave blank to allow every page to be edited.
 
 private-pages:
-# specifies pages that are considered private, i.e not accessible for
-# anonymous users. This setting overrides any other require-authentication
-# setting, visitors to private pages must be logged in.
-# Full paths and wildcards are both available, meaning that
-# /Dir/Page, /Dir/* and */Page will all blacklist
-# the /Dir/Page page.
+# specifies a comma-separated list of page paths that are considered
+# private, i.e not accessible for anonymous users. This setting overrides
+# any other require-authentication setting, visitors to private pages must
+# be logged in. Full paths and wildcards are both available, meaning that
+# Dir/Page, Dir/* and */Page will all blacklist the Dir/Page page.
 
 default-summary:
 # specifies text to be used in the change description if the author

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -172,7 +172,8 @@ Library
                      network-uri >= 2.6,
                      network >= 2.6 && < 3.2,
                      network-bsd >= 2.8.1 && < 2.9,
-                     doctemplates >= 0.7.1
+                     doctemplates >= 0.7.1,
+                     Glob >= 0.7.9
   if flag(plugins)
     exposed-modules: Network.Gitit.Interface
     build-depends:   ghc, ghc-paths

--- a/src/Network/Gitit.hs
+++ b/src/Network/Gitit.hs
@@ -142,7 +142,7 @@ wiki conf = do
         serveDirectory' static `mplus` serveDirectory' defaultStatic
   let debugHandler' = msum [debugHandler | debugMode conf]
   let handlers = debugHandler' `mplus` authHandler conf `mplus`
-                 authenticate ForRead (msum wikiHandlers)
+                 authenticate ForRead (unlessPrivatePage showPage redirectToLogin `mplus` msum wikiHandlers)
   let fs = filestoreFromConfig conf
   let ws = WikiState { wikiConfig = conf, wikiFileStore = fs }
   if compressResponses conf

--- a/src/Network/Gitit.hs
+++ b/src/Network/Gitit.hs
@@ -141,8 +141,9 @@ wiki conf = do
   let staticHandler = withExpiresHeaders $
         serveDirectory' static `mplus` serveDirectory' defaultStatic
   let debugHandler' = msum [debugHandler | debugMode conf]
+  let privatePageHandler = unlessPrivatePage (authenticate ForRead showPage) (authenticate Never showPage)
   let handlers = debugHandler' `mplus` authHandler conf `mplus`
-                 authenticate ForRead (unlessPrivatePage showPage redirectToLogin `mplus` msum wikiHandlers)
+                 privatePageHandler `mplus` (msum wikiHandlers)
   let fs = filestoreFromConfig conf
   let ws = WikiState { wikiConfig = conf, wikiFileStore = fs }
   if compressResponses conf

--- a/src/Network/Gitit/Config.hs
+++ b/src/Network/Gitit/Config.hs
@@ -108,6 +108,7 @@ extractConfig cp = do
       cfFrontPage <- get cp "DEFAULT" "front-page"
       cfNoEdit <- get cp "DEFAULT" "no-edit"
       cfNoDelete <- get cp "DEFAULT" "no-delete"
+      cfPrivatePages <- get cp "DEFAULT" "private-pages"
       cfDefaultSummary <- get cp "DEFAULT" "default-summary"
       cfDeleteSummary <- get cp "DEFAULT" "delete-summary"
       cfDisableRegistration <- get cp "DEFAULT" "disable-registration"
@@ -207,6 +208,7 @@ extractConfig cp = do
         , frontPage            = cfFrontPage
         , noEdit               = splitCommaList cfNoEdit
         , noDelete             = splitCommaList cfNoDelete
+        , privatePages         = splitCommaList cfPrivatePages
         , defaultSummary       = cfDefaultSummary
         , deleteSummary        = cfDeleteSummary
         , disableRegistration  = cfDisableRegistration

--- a/src/Network/Gitit/Framework.hs
+++ b/src/Network/Gitit/Framework.hs
@@ -209,7 +209,7 @@ unlessPrivatePage responder fallback =
     let patterns = privatePages cfg
     let pageMatchingPatterns = ((flip G.match page) . G.compile)
     if ((not . null) patterns) && (any pageMatchingPatterns patterns)
-      then withMessages ("Page is private, you must log in to view." : pMessages params) fallback
+      then fallback
       else responder
 
 -- | Returns the current path (subtracting initial commands like @\/_edit@).

--- a/src/Network/Gitit/Framework.hs
+++ b/src/Network/Gitit/Framework.hs
@@ -24,9 +24,11 @@ module Network.Gitit.Framework (
                                , authenticateUserThat
                                , authenticate
                                , getLoggedInUser
+                               , redirectToLogin
                                -- * Combinators to exclude certain actions
                                , unlessNoEdit
                                , unlessNoDelete
+                               , unlessPrivatePage
                                -- * Guards for routing
                                , guardCommand
                                , guardPath
@@ -98,6 +100,13 @@ authenticateUserThat predicate level handler = do
                             then handler
                             else error "Not authorized."
      else handler
+
+-- | Redirects a request to login view, used as a failure handler.
+redirectToLogin :: Handler
+redirectToLogin = do
+  rq <- askRq
+  let url = rqUri rq ++ rqQuery rq
+  tempRedirect ("/_login?" ++ urlEncodeVars [("destination", url)]) $ toResponse ()
 
 -- | Run the handler after setting @REMOTE_USER@ with the user from
 -- the session.

--- a/src/Network/Gitit/Framework.hs
+++ b/src/Network/Gitit/Framework.hs
@@ -72,6 +72,7 @@ import Skylighting (syntaxesByFilename, defaultSyntaxMap)
 import Data.Maybe (fromJust, fromMaybe)
 import Data.List (intercalate, isPrefixOf, isInfixOf)
 import System.FilePath ((<.>), takeExtension, takeFileName)
+import qualified System.FilePath.Glob as G
 import Text.ParserCombinators.Parsec
 import Network.URL (decString, encString)
 import Network.URI (isUnescapedInURI)
@@ -205,27 +206,11 @@ unlessPrivatePage responder fallback =
   withData $ \(params :: Params) -> do
     cfg <- getConfig
     page <- getPage
-    let pps = privatePages cfg
-    if pageIsPrivate page pps
+    let patterns = privatePages cfg
+    let pageMatchingPatterns = ((flip G.match page) . G.compile)
+    if ((not . null) patterns) && (any pageMatchingPatterns patterns)
       then withMessages ("Page is private, you must log in to view." : pMessages params) fallback
       else responder
-
-      where pageIsPrivate :: String -> [String] -> Bool
-            pageIsPrivate _ [] = False
-            pageIsPrivate p ps | wildcardExists ps = p `elem` ps || pageMatchWildcards p (filter (elem '*') ps)
-                               | otherwise = p `elem` ps
-
-            wildcardExists :: [String] -> Bool
-            wildcardExists = foldr (\s b -> ('*' `elem` s) || b) False
-
-            pageMatchWildcards :: String -> [String] -> Bool
-            pageMatchWildcards p ps = any (isInfixOfAll p) (patterns ps)
-
-            patterns :: [String] -> [[String]]
-            patterns = map (filter (not . null) . splitOn '*')
-
-            isInfixOfAll :: String -> [String] -> Bool
-            isInfixOfAll p = foldr (\x -> (&&) (x `isInfixOf` p)) True
 
 -- | Returns the current path (subtracting initial commands like @\/_edit@).
 getPath :: ServerMonad m => m String

--- a/src/Network/Gitit/Framework.hs
+++ b/src/Network/Gitit/Framework.hs
@@ -195,6 +195,38 @@ unlessNoDelete responder fallback = withData $ \(params :: Params) -> do
      then withMessages ("Page cannot be deleted." : pMessages params) fallback
      else responder
 
+-- | @unlessPrivatePage responder fallback@ runs @responder@ unless the
+-- page is specified as private in configuration; in that case, runs
+-- @fallback@
+unlessPrivatePage :: Handler
+                  -> Handler
+                  -> Handler
+unlessPrivatePage responder fallback =
+  withData $ \(params :: Params) -> do
+    cfg <- getConfig
+    page <- getPage
+    let pps = privatePages cfg
+    if pageIsPrivate page pps
+      then withMessages ("Page is private, you must log in to view." : pMessages params) fallback
+      else responder
+
+      where pageIsPrivate :: String -> [String] -> Bool
+            pageIsPrivate _ [] = False
+            pageIsPrivate p ps | wildcardExists ps = p `elem` ps || pageMatchWildcards p (filter (elem '*') ps)
+                               | otherwise = p `elem` ps
+
+            wildcardExists :: [String] -> Bool
+            wildcardExists = foldr (\s b -> ('*' `elem` s) || b) False
+
+            pageMatchWildcards :: String -> [String] -> Bool
+            pageMatchWildcards p ps = any (isInfixOfAll p) (patterns ps)
+
+            patterns :: [String] -> [[String]]
+            patterns = map (filter (not . null) . splitOn '*')
+
+            isInfixOfAll :: String -> [String] -> Bool
+            isInfixOfAll p = foldr (\x -> (&&) (x `isInfixOf` p)) True
+
 -- | Returns the current path (subtracting initial commands like @\/_edit@).
 getPath :: ServerMonad m => m String
 getPath = liftM (intercalate "/" . rqPaths) askRq

--- a/src/Network/Gitit/Types.hs
+++ b/src/Network/Gitit/Types.hs
@@ -160,7 +160,7 @@ data Config = Config {
   noEdit               :: [String],
   -- | Pages that cannot be deleted via web
   noDelete              :: [String],
-  -- | Pages that must cannot be edited by anonymous users.
+  -- | Pages that cannot be viewed by anonymous users.
   privatePages          :: [String],
   -- | Default summary if description left blank
   defaultSummary       :: String,

--- a/src/Network/Gitit/Types.hs
+++ b/src/Network/Gitit/Types.hs
@@ -159,7 +159,9 @@ data Config = Config {
   -- | Pages that cannot be edited via web
   noEdit               :: [String],
   -- | Pages that cannot be deleted via web
-  noDelete             :: [String],
+  noDelete              :: [String],
+  -- | Pages that must cannot be edited by anonymous users.
+  privatePages          :: [String],
   -- | Default summary if description left blank
   defaultSummary       :: String,
   -- | Delete summary


### PR DESCRIPTION
Hello,
The feature allowing private pages is interesting. I simply rebased the PR #579 commits and all works! In response to the initial pull request, I've added some documentation on how it works.
For the sake of completeness, it would be preferable for these private pages to be filtered in the pages "All pages" or "Recent activity", but I'm unable to do that in haskell :cry: 
Do you think this feature could be merged as it stands?