### PR TITLE
feat(Config): Add json config format option

### DIFF
--- a/data/default.conf
+++ b/data/default.conf
@@ -1,5 +1,15 @@
 # gitit wiki configuration file
 
+# NOTE: you can also use a json syntax for configuration files. Create a toplevel object, and nest sections as objects within that object. For example:
+# {
+#   "redirect": "yes",
+#   "address": "0.0.0.0",
+#   "[Github]": {
+#     "oauthclientid": "01239456789abcdef012",
+#     "oauthclientsecret": "01239456789abcdef01239456789abcdef012394",
+#   }
+# }
+
 address: 0.0.0.0
 # sets the IP address on which the web server will listen.
 

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -157,6 +157,7 @@ Library
                      feed >= 1.0 && < 1.4,
                      xml-types >= 0.3,
                      xss-sanitize >= 0.3 && < 0.4,
+                     scientific >= 0.3 && < 0.4,
                      tagsoup >= 0.13 && < 0.15,
                      blaze-html >= 0.4 && < 0.10,
                      json >= 0.4 && < 0.12,


### PR DESCRIPTION
In order to make it easier to generate gitit configuration, we add the ability for config files to be json values in addition to the custom config format parser.

This should be 100% backward-compatible, with the error messages being reasonably clear about the fallback mechanism.

Json strings, numbers and booleans are supported as-is, and the default section also works (sections are distinguished by their name being in `[brackets]`).

Potentially a bit more documentation might be needed.