### PR TITLE
Fix Redirect <meta> header

### DIFF
--- a/src/Network/Gitit/ContentTransformer.hs
+++ b/src/Network/Gitit/ContentTransformer.hs
@@ -476,7 +476,7 @@ handleRedirects page = case lookup "redirect" (pageMeta page) of
                 lift $ ok $ withBody $ concat
                     [ "<!doctype html><html><head><title>Redirecting to "
                     , html'
-                    , "</title><meta http-equiv=\"refresh\" contents=\"0; url="
+                    , "</title><meta http-equiv=\"refresh\" content=\"0; url="
                     , url'
                     , "\" /><script type=\"text/javascript\">window.location=\""
                     , url'


### PR DESCRIPTION
The attribute to redirect to a different page is called `content` not `contents` (I guess that means the no-js redirect was broken since the thing was added?)