### PR TITLE
Html5 everywhere

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -567,7 +567,7 @@ Now add the following lines to the apache configuration file for the
       SetOutputFilter  proxy-html
       ProxyPassReverse /
       ProxyHTMLURLMap  /   /wiki/
-      ProxyHTMLDocType "<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Strict//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>" XHTML
+      ProxyHTMLDocType html5
       RequestHeader unset Accept-Encoding
     </Location>
 

--- a/data/markup.HTML
+++ b/data/markup.HTML
@@ -1,6 +1,6 @@
 # Markup
 
-The syntax for wiki pages is standard XHTML. All tags must be
+The syntax for wiki pages is standard HTML 5. All tags must be
 properly closed.
 
 ## Wiki links

--- a/data/markupHelp/HTML
+++ b/data/markupHelp/HTML
@@ -45,6 +45,6 @@ external</a>,
 </dl>
 ~~~~~~~~
 
-For more: [xhtml tutorial](http://www.w3schools.com/Xhtml/),
+For more: [HTML tutorial](https://developer.mozilla.org/en-US/docs/Learn/HTML),
 [pandoc](http://pandoc.org/README.html).
 

--- a/data/templates/page.st
+++ b/data/templates/page.st
@@ -1,6 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/gitit.cabal
+++ b/gitit.cabal
@@ -158,7 +158,7 @@ Library
                      xml-types >= 0.3,
                      xss-sanitize >= 0.3 && < 0.4,
                      tagsoup >= 0.13 && < 0.15,
-                     blaze-html >= 0.4 && < 0.10,
+                     blaze-html >= 0.5 && < 0.10,
                      json >= 0.4 && < 0.12,
                      uri-bytestring >= 0.2.3.3,
                      split,

--- a/src/Network/Gitit/ContentTransformer.hs
+++ b/src/Network/Gitit/ContentTransformer.hs
@@ -476,7 +476,7 @@ handleRedirects page = case lookup "redirect" (pageMeta page) of
                 lift $ ok $ withBody $ concat
                     [ "<!doctype html><html><head><title>Redirecting to "
                     , html'
-                    , "</title><meta http-equiv=\"refresh\" contents=\"0; url="
+                    , "</title><meta http-equiv=\"refresh\" content=\"0; url="
                     , url'
                     , "\" /><script type=\"text/javascript\">window.location=\""
                     , url'

--- a/src/Network/Gitit/ContentTransformer.hs
+++ b/src/Network/Gitit/ContentTransformer.hs
@@ -95,11 +95,7 @@ import Skylighting hiding (Context)
 import Text.Pandoc hiding (MathML, WebTeX, MathJax)
 import Text.XHtml hiding ( (</>), dir, method, password, rev )
 import Text.XHtml.Strict (stringToHtmlString)
-#if MIN_VERSION_blaze_html(0,5,0)
 import Text.Blaze.Html.Renderer.String as Blaze ( renderHtml )
-#else
-import Text.Blaze.Renderer.String as Blaze ( renderHtml )
-#endif
 import URI.ByteString (Query(Query), URIRef(uriPath), laxURIParserOptions,
                        parseURI, uriQuery)
 import qualified Data.Text as T

--- a/src/Network/Gitit/Types.hs
+++ b/src/Network/Gitit/Types.hs
@@ -70,7 +70,6 @@ import Control.Monad.State (StateT, runStateT, get, modify)
 import Control.Monad (liftM, mplus)
 import System.Log.Logger (Priority(..))
 import Text.Pandoc.Definition (Pandoc)
-import Text.XHtml (Html)
 import qualified Data.Map as M
 import Data.Text (Text)
 import Data.List (intersect)
@@ -85,6 +84,7 @@ import Network.Gitit.Server
 import Text.HTML.TagSoup.Entity (lookupEntity)
 import Data.Char (isSpace)
 import Network.OAuth.OAuth2
+import Text.Blaze.Html (Html)
 
 data PageType = Markdown
               | CommonMark


### PR DESCRIPTION
This is a rather mechanical translation from the old `xhtml` library
to the more modern `blaze` library.

We use HTML5 everywhere, thus we also change the `DOCTYPE`.

Pandoc needs to be configured to return HTML5 as well, but it looks
like every use of the html writer already uses `writeHtml5String`. So
I guess we are good?