### PR TITLE
State: Remove unnecessary templates state field

### DIFF
--- a/gitit.hs
+++ b/gitit.hs
@@ -105,7 +105,7 @@ main = do
 
   -- start the server
   simpleHTTPWithSocket sock serverConf $ msum [ wiki conf
-                               , dir "_reloadTemplates" reloadTemplates
+                               , dir "_reloadTemplates" (reloadTemplates conf)
                                ]
 
 data ExitOpt

--- a/src/Network/Gitit.hs
+++ b/src/Network/Gitit.hs
@@ -210,9 +210,9 @@ wikiHandlers =
   ]
 
 -- | Recompiles the gitit templates.
-reloadTemplates :: ServerPart Response
-reloadTemplates = do
-  liftIO recompilePageTemplate
+reloadTemplates :: Config -> ServerPart Response
+reloadTemplates cfg = do
+  liftIO $ recompilePageTemplate cfg
   ok $ toResponse "Page templates have been recompiled."
 
 -- | Converts a gitit Handler into a standard happstack ServerPart.

--- a/src/Network/Gitit/Initialize.hs
+++ b/src/Network/Gitit/Initialize.hs
@@ -63,15 +63,13 @@ initializeGititState conf = do
 
   updateGititState $ \s -> s { sessions      = Sessions M.empty
                              , users         = users'
-                             , templatesPath = templatesDir conf
                              , renderPage    = defaultRenderPage templ
                              , plugins       = plugins' }
 
 -- | Recompile the page template.
-recompilePageTemplate :: IO ()
-recompilePageTemplate = do
-  tempsDir <- queryGititState templatesPath
-  ct <- compilePageTemplate tempsDir
+recompilePageTemplate :: Config -> IO ()
+recompilePageTemplate cfg = do
+  ct <- compilePageTemplate (templatesDir cfg)
   updateGititState $ \st -> st{renderPage = defaultRenderPage ct}
 
 --- | Compile a master page template named @page.st@ in the directory specified.

--- a/src/Network/Gitit/State.hs
+++ b/src/Network/Gitit/State.hs
@@ -39,7 +39,6 @@ import Network.Gitit.Types
 gititstate :: IORef GititState
 gititstate = unsafePerformIO $  newIORef  GititState { sessions = undefined
                                                      , users = undefined
-                                                     , templatesPath = undefined
                                                      , renderPage = undefined
                                                      , plugins = undefined }
 

--- a/src/Network/Gitit/Types.hs
+++ b/src/Network/Gitit/Types.hs
@@ -263,7 +263,6 @@ data User = User {
 data GititState = GititState {
   sessions       :: Sessions SessionData,
   users          :: M.Map String User,
-  templatesPath  :: FilePath,
   renderPage     :: PageLayout -> Html -> Handler,
   plugins        :: [Plugin]
 }


### PR DESCRIPTION
The templates are directly pulled out of the config and then never changed, so no reason to put the field in state.

There’s also no way to generate or change the state through some other mechanism as far as I can see.