### PR TITLE
adds new config option: pandoc-extensions

### DIFF
--- a/src/Network/Gitit/Config.hs
+++ b/src/Network/Gitit/Config.hs
@@ -154,6 +154,7 @@ extractConfig cfgmap = do
   cfFrontPage <- get "DEFAULT" "front-page"
   cfNoEdit <- get "DEFAULT" "no-edit"
   cfNoDelete <- get "DEFAULT" "no-delete"
+  cfPandocExtensions <- get "DEFAULT" "pandoc-extensions"
   cfDefaultSummary <- get "DEFAULT" "default-summary"
   cfDeleteSummary <- get "DEFAULT" "delete-summary"
   cfDisableRegistration <- get "DEFAULT" "disable-registration" >>= readBool
@@ -250,6 +251,7 @@ extractConfig cfgmap = do
     , noDelete             = splitCommaList cfNoDelete
     , defaultSummary       = cfDefaultSummary
     , deleteSummary        = cfDeleteSummary
+    , pandocExts           = splitCommaList cfPandocExtensions
     , disableRegistration  = cfDisableRegistration
     , accessQuestion       = if null cfAccessQuestion
                                 then Nothing

--- a/src/Network/Gitit/Types.hs
+++ b/src/Network/Gitit/Types.hs
@@ -160,6 +160,8 @@ data Config = Config {
   noEdit               :: [String],
   -- | Pages that cannot be deleted via web
   noDelete             :: [String],
+  -- | Pandoc extensions to enable (don't include the "Ext_" prefix)
+  pandocExts           :: [String],
   -- | Default summary if description left blank
   defaultSummary       :: String,
   -- | Delete summary


### PR DESCRIPTION
Enables users to enable Pandoc extensions using the gitit.conf file.

I have tested this on my machine using this addition to gitit.conf:
  pandoc-extensions: wikilinks_title_after_pipe

Note that I'm a Haskell novice and new to the Gitit code too.  