### PR TITLE
Fix for `pandoc-3.8`

### DIFF
--- a/gitit.cabal
+++ b/gitit.cabal
@@ -134,7 +134,7 @@ Library
                      mtl,
                      old-time,
                      temporary,
-                     pandoc >= 2.9 && < 2.20 || >= 3.0 && < 3.8,
+                     pandoc >= 2.9 && < 2.20 || >= 3.0 && < 3.9,
                      pandoc-types >= 1.20 && < 1.24,
                      skylighting >= 0.8.2.3 && < 0.15,
                      bytestring,

--- a/src/Network/Gitit/ContentTransformer.hs
+++ b/src/Network/Gitit/ContentTransformer.hs
@@ -515,7 +515,7 @@ pandocToHtml pandocContents = do
                                  MathJax u -> Pandoc.MathJax $ T.pack u
                                  RawTeX -> Pandoc.PlainMath
                       , writerTableOfContents = toc
-                      , writerHighlightStyle = Just pygments
+                      , writerHighlightMethod = Skylighting pygments
                       , writerExtensions = if bird
                                               then enableExtension Ext_literate_haskell
                                                    $ writerExtensions def


### PR DESCRIPTION
Currently, building `gitit` with `pandoc-3.8` fails with:

```
[12 of 21] Compiling Network.Gitit.ContentTransformer ( src/Network/Gitit/ContentTransformer.hs, dist/build/Network/Gitit/ContentTransformer.o, dist/build/Network/Gitit/ContentTransformer.dyn_o )

src/Network/Gitit/ContentTransformer.hs:523:25: error: [GHC-22385]
    Not in scope: record field ‘writerHighlightStyle’
    Suggested fix:
      Perhaps use record field of WriterOptions ‘writerHighlightMethod’ (imported from Text.Pandoc)
    |
523 |                       , writerHighlightStyle = Just pygments
    |                         ^^^^^^^^^^^^^^^^^^^^
```

But, it is an easy fix.